### PR TITLE
Do some cleanup & add a /user page for showing hardcoded user info  

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Pretty slick. 😎
 npm install
 
 # run application in 'dev' mode
-npm start
+npm run dev
 
 # run application in 'prod' mode
 npm start

--- a/src/__tests__/server.test.js
+++ b/src/__tests__/server.test.js
@@ -30,4 +30,9 @@ describe('Test server responses', () => {
     const response = await request(app).get('/alpha')
     expect(response.text).toContain('<h1>Alpha</h1>')
   })
+
+  test('it should return "Dashboard" in the h1 tag for /user', async () => {
+    const response = await request(app).get('/user')
+    expect(response.text).toContain('<h1>Dashboard</h1>')
+  })
 })

--- a/src/__tests__/server.test.js
+++ b/src/__tests__/server.test.js
@@ -1,11 +1,6 @@
 const request = require('supertest')
 const app = require('../server.js')
 
-beforeEach(() => {
-  // eslint-disable-next-line no-console
-  console.log = jest.fn()
-})
-
 describe('Test server responses', () => {
   test('it should return 200 for the root path', async () => {
     const response = await request(app).get('/')
@@ -15,7 +10,7 @@ describe('Test server responses', () => {
   test('it should return security-focused headers in reponses', async () => {
     const response = await request(app).get('/')
 
-    /* 
+    /*
       More documentaion on each of these can be found here:
       - https://helmetjs.github.io/docs/
     */

--- a/src/components/__tests__/SummaryTable.test.js
+++ b/src/components/__tests__/SummaryTable.test.js
@@ -1,0 +1,81 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils.js')
+
+const SummaryTable = require('../SummaryTable.js')
+
+const getCell = ({ cheerio, rowNum = 0, find }) =>
+  cheerio('dl div')
+    .eq(rowNum)
+    .find(find)
+
+describe('<SummaryTable>', () => {
+  test('renders <dl> element and 1 row', () => {
+    const rows = [{ key: 'Full name', value: 'Fred Smith' }]
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${SummaryTable} rows=${rows} />
+        `,
+      ),
+    )
+    expect($('dl').length).toBe(1)
+    expect($('dl div').length).toBe(1)
+  })
+
+  test('renders correct cells with 1 row', () => {
+    const rows = [{ key: 'Full name', value: 'Fred Smith' }]
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${SummaryTable} rows=${rows} />
+        `,
+      ),
+    )
+
+    // first row
+    expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual(
+      'Full name',
+    )
+    expect(getCell({ cheerio: $, rowNum: 0, find: '.value' }).text()).toEqual(
+      'Fred Smith',
+    )
+    expect(getCell({ cheerio: $, rowNum: 0, find: '.action' }).text()).toEqual(
+      'Change full name',
+    )
+    expect(
+      getCell({ cheerio: $, rowNum: 0, find: '.action a' }).attr('href'),
+    ).toEqual('/edit')
+  })
+
+  test('renders correct cells with 2 rows', () => {
+    const rows = [
+      { key: 'Full name', value: 'Fred Smith' },
+      { key: 'Date of birth', value: '18-06-1971' },
+    ]
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${SummaryTable} rows=${rows} />
+        `,
+      ),
+    )
+
+    // second row
+    expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual(
+      'Date of birth',
+    )
+    expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual(
+      '18-06-1971',
+    )
+    expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).text()).toEqual(
+      'Change date of birth',
+    )
+    expect(
+      getCell({ cheerio: $, rowNum: 1, find: '.action a' }).attr('href'),
+    ).toEqual('/edit')
+  })
+})

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -27,19 +27,26 @@ const makeRows = ({ sin, dobDay, dobMonth, dobYear, name, address }) => {
   ]
 }
 
-const Dashboard = ({ data = {} }) =>
+const Dashboard = ({ data = {}, test = false }) =>
   html`
     <${Layout}>
       <div class=${dashboard}>
-        <${LogoutLink} />
+        ${!test &&
+          html`
+            <${LogoutLink} />
+          `}
         <h1>Dashboard</h1>
         <div>
           <${SummaryTable} rows=${makeRows(data)} //>
         </div>
 
         <br />
+
         <form method="get" action="/confirmation">
-        <${Button} style=${submitButton}>Submit taxes<//>
+        ${!test &&
+          html`
+            <${Button} style=${submitButton}>Submit taxes<//>
+          `}
         </form>
       </div>
     </${Layout}>

--- a/src/pages/__tests__/Document.test.js
+++ b/src/pages/__tests__/Document.test.js
@@ -1,0 +1,60 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils.js')
+
+const Dashboard = require('../Dashboard.js')
+
+describe('<Dashboard>', () => {
+  const data = {
+    name: 'Fred Smith',
+    sin: '123-456-789',
+    dobDay: '18',
+    dobMonth: '06',
+    dobYear: '1971',
+    address: 'Mississauga',
+  }
+
+  const expectedStrings = [
+    'Fred Smith',
+    '123-456-789',
+    '18-06-1971',
+    'Mississauga',
+  ]
+
+  test('renders h1 as expected', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Dashboard} data=${data} />
+        `,
+      ),
+    )
+    expect($('h1').length).toBe(1)
+    expect($('h1').text()).toEqual('Dashboard')
+
+    expect($('button').length).toBe(1)
+    expect($('button').text()).toEqual('Submit taxes')
+
+    expect($('a[href="/logout"]').length).toBe(1)
+    expect($('a[href="/logout"]').text()).toEqual('Log out')
+  })
+
+  expectedStrings.map(str => {
+    test(`renders ${str} on page`, () => {
+      const $ = cheerio.load(
+        render(
+          html`
+            <${Dashboard} data=${data} />
+          `,
+        ),
+      )
+      expect($('h1').text()).toEqual('Dashboard')
+
+      expect(
+        $('h1')
+          .next()
+          .html(),
+      ).toContain(str)
+    })
+  })
+})

--- a/src/server.js
+++ b/src/server.js
@@ -110,7 +110,7 @@ app.get('/logout', (req, res) => {
   res.redirect(302, '/login')
 })
 
-/* TODO: delete this by Thursday, April 11th */
+/* TODO: delete this by Monday, April 15th */
 app.get('/alpha', (req, res) => {
   const content =
     '<h1>Alpha</h1> \
@@ -118,6 +118,26 @@ app.get('/alpha', (req, res) => {
     <p>[Full name]</p>'
 
   res.send(_renderDocument({ title: 'Alpha', locale, content }))
+})
+
+/* TODO: delete this by Wednesday, April 17th */
+app.get('/user', (req, res) => {
+  const data = {
+    name: 'Matthew Morris',
+    address: '380 Lewis St\nOttawa\nOntario\nK2P 2P6',
+    sin: '123-456-789',
+    dobDay: '28',
+    dobMonth: '02',
+    dobYear: '1992',
+  }
+
+  res.send(
+    renderPage({
+      locale,
+      pageComponent: 'Dashboard',
+      props: { data, test: true },
+    }),
+  )
 })
 
 module.exports = app


### PR DESCRIPTION
## Create "/user" route with hardcoded user information

It's all hardcoded, but it checks the boxes of the acceptance criteria for the "user information is on the screen" story. 

### Add unit tests for Dashboard and SummaryTable

Both are used to show user information.

## Update the README 

Update the "run in dev mode" instructions because they were wrong.

## Remove console suppression in server unit tests

Previously, we were actually starting the server when we were importing it, so then we would see the log message on the terminal.

Since we're not doing that anymore, we don't have to suppress `console.log`.