### PR TITLE
Online confirmation: Initial view

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "semi": false,
-  "parser": "babylon",
+  "parser": "babel",
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "printWidth": 100
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
   "semi": false,
-  "parser": "babel",
   "singleQuote": true,
   "trailingComma": "all",
   "printWidth": 100

--- a/src/__tests__/session.test.js
+++ b/src/__tests__/session.test.js
@@ -8,6 +8,7 @@ const validNames = [
   'k',
   'K',
   'KIM',
+  '\t\t  \n KIM', // leading whitespace doesn't matter
   'KIM    \t\t  \n ', // trailing whitespace doesn't matter
   'kim', // captialization isn't important
   'Avril',
@@ -34,7 +35,6 @@ const invalidNames = [
   'b', // only some letters are allowed
   'kk',
   'Ki',
-  ' KIM', // leading whitespace will fail
   'Avri', // impartial names are generally going to fail
   'Douglas', // middle names don't work
   'Campbell', // last names don't work

--- a/src/api.js
+++ b/src/api.js
@@ -37,6 +37,8 @@ var API = (function() {
 
   const _users = [_john, _arthur, _louis, _kim]
 
+  const getFirstName = (name = '') => name.trim().split(' ')[0]
+
   const getUser = name => {
     let found = null
 
@@ -44,7 +46,7 @@ var API = (function() {
       return found
     }
 
-    const firstName = name.split(' ')[0].toLowerCase()
+    const firstName = getFirstName(name).toLowerCase()
 
     _users.forEach(user => {
       if (user._matches.includes(firstName)) {
@@ -60,6 +62,7 @@ var API = (function() {
   }
 
   return {
+    getFirstName,
     getUser,
     getMatches,
   }

--- a/src/components/ButtonLink.js
+++ b/src/components/ButtonLink.js
@@ -1,0 +1,30 @@
+const { Component } = require('preact')
+const { buttonStyles } = require('../styles.js')
+const { html } = require('../utils.js')
+
+class ButtonLink extends Component {
+  render({ children, href, style = '', ...props }) {
+    return html`
+      <span>
+        <a
+          href=${href}
+          class=${`${buttonStyles} ${style} buttonLink`}
+          role="button"
+          draggable="false"
+          ...${props}
+        >
+          ${children}
+        </a>
+        <script>
+          document.querySelector('.buttonLink').addEventListener('keydown', function(e) {
+            if (e.keyCode == 32) {
+              e.target.click()
+            }
+          })
+        </script>
+      </span>
+    `
+  }
+}
+
+module.exports = ButtonLink

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,0 +1,30 @@
+const { css } = require('emotion')
+const { theme, pageMargin } = require('../styles.js')
+const { html } = require('../utils.js')
+
+const footer = css`
+  padding-top: ${theme.space.xs};
+  padding-bottom: ${theme.space.xs};
+  border-top: 2px solid ${theme.color.black};
+  height: 50px; /* footer height */
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+
+  div {
+    ${pageMargin};
+  }
+
+  a {
+    font-size: 0.85em;
+  }
+`
+
+const Footer = () =>
+  html`
+    <footer class=${footer}>
+      <div><a href="#">Get help</a></div>
+    </footer>
+  `
+
+module.exports = Footer

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,13 +1,19 @@
 const { css } = require('emotion')
-const { theme } = require('../styles.js')
+const { theme, pageMargin } = require('../styles.js')
 const { html } = require('../utils.js')
 const AlphaBanner = require('../components/AlphaBanner.js')
+const Footer = require('../components/Footer.js')
 
-const main = css`
-  max-width: 900px;
-  margin: 0 auto;
-  margin-bottom: ${theme.space.xl};
-  padding: 0 ${theme.space.md};
+const layout = css`
+  position: relative;
+  min-height: 100vh;
+
+  main {
+    ${pageMargin};
+
+    /* footer height (50px) + xxl spacing */
+    padding-bottom: calc(50px + ${theme.space.xxl});
+  }
 `
 
 const blackBar = css`
@@ -18,12 +24,13 @@ const blackBar = css`
 
 const Layout = ({ children }) =>
   html`
-    <div>
+    <div class=${layout}>
       <div class=${blackBar}></div>
-      <main class=${main}>
+      <main>
         <${AlphaBanner} />
         ${children}
       </main>
+      <${Footer} />
     </div>
   `
 

--- a/src/components/__tests__/AlphaBanner.test.js
+++ b/src/components/__tests__/AlphaBanner.test.js
@@ -4,7 +4,7 @@ const { html } = require('../../utils.js')
 
 const AlphaBanner = require('../AlphaBanner.js')
 
-test('AlphaBanner renders as expected', () => {
+test('<AlphaBanner> renders as expected', () => {
   const $ = cheerio.load(
     render(
       html`

--- a/src/components/__tests__/ButtonLink.test.js
+++ b/src/components/__tests__/ButtonLink.test.js
@@ -1,0 +1,40 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils.js')
+
+const ButtonLink = require('../ButtonLink.js')
+
+describe('<ButtonLink>', () => {
+  test('renders as expected', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${ButtonLink} href="#">Submit<//>
+        `,
+      ),
+    )
+    expect($('a').length).toBe(1)
+    expect($('a').text()).toEqual('Submit')
+    expect($('a').attr('href')).toEqual('#')
+    expect($('a').attr('class')).toContain('buttonLink')
+    expect($('a').attr('role')).toEqual('button')
+    expect($('a').attr('draggable')).toEqual('false')
+
+    expect($('script').length).toBe(1)
+  })
+
+  test('renders with passed-in attributes', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${ButtonLink} href="/logout" style="orange" whizz="bang" download>Log out<//>
+        `,
+      ),
+    )
+    expect($('a').length).toBe(1)
+    expect($('a').text()).toEqual('Log out')
+    expect($('a').attr('whizz')).toEqual('bang')
+    expect($('a').attr('class')).toContain('orange buttonLink')
+    expect($('a').attr('download')).toBeDefined()
+  })
+})

--- a/src/components/__tests__/Footer.test.js
+++ b/src/components/__tests__/Footer.test.js
@@ -1,0 +1,18 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../utils.js')
+
+const Footer = require('../Footer.js')
+
+test('<Footer> renders as expected', () => {
+  const $ = cheerio.load(
+    render(
+      html`
+        <${Footer} />
+      `,
+    ),
+  )
+  expect($('div').length).toBe(1)
+  expect($('div a').length).toBe(1)
+  expect($('a').text()).toEqual('Get help')
+})

--- a/src/components/__tests__/Layout.test.js
+++ b/src/components/__tests__/Layout.test.js
@@ -4,7 +4,7 @@ const { html } = require('../../utils.js')
 
 const Layout = require('../Layout.js')
 
-test('Layout wraps children with <main> element', () => {
+test('<Layout> wraps children with <main> element', () => {
   const $ = cheerio.load(
     render(
       html`

--- a/src/components/__tests__/LogoutLink.test.js
+++ b/src/components/__tests__/LogoutLink.test.js
@@ -4,7 +4,7 @@ const { html } = require('../../utils.js')
 
 const LogoutLink = require('../LogoutLink.js')
 
-test('LogoutLink renders as expected', () => {
+test('<LogoutLink> renders as expected', () => {
   const $ = cheerio.load(
     render(
       html`

--- a/src/components/forms/Button.js
+++ b/src/components/forms/Button.js
@@ -1,28 +1,9 @@
-const { css } = require('emotion')
-const { theme } = require('../../styles.js')
+const { buttonStyles } = require('../../styles.js')
 const { html } = require('../../utils.js')
-
-const button = css`
-  font: 400 1em sans-serif;
-  line-height: 1.1875;
-  display: inline-block;
-  position: relative;
-  width: 100%;
-  margin-top: 0;
-  padding: 7px 10px;
-  border-radius: 0;
-  color: ${theme.color.black};
-  background-color: ${theme.color.green};
-  border: 2px solid ${theme.color.grey};
-  text-align: center;
-  vertical-align: top;
-  cursor: pointer;
-  -webkit-appearance: none;
-`
 
 const Button = ({ children, type = 'submit', style = '', ...props }) =>
   html`
-    <button type=${type} class=${`${button} ${style}`} ...${props}>
+    <button type=${type} class=${`${buttonStyles} ${style}`} ...${props}>
       ${children}
     </button>
   `

--- a/src/pages/Confirmation.js
+++ b/src/pages/Confirmation.js
@@ -1,6 +1,7 @@
 const { css } = require('emotion')
 const { theme } = require('../styles.js')
 const { html } = require('../utils.js')
+const { getFirstName } = require('../api.js')
 const Layout = require('../components/Layout.js')
 const LogoutLink = require('../components/LogoutLink.js')
 
@@ -29,7 +30,7 @@ const Confirmation = ({ data: { name = '' } = {} }) =>
       <div class=${confirmation}>
         <${LogoutLink} />
         <h1>Success! 🥳🙌</h1>
-        <p>🌈 Good job, ${name.split(' ')[0]}! 🌈</p>
+        <p>🌈 Good job, ${getFirstName(name)}! 🌈</p>
         <p>
           Your 2018 taxes have been submitted and${' '}
           <strong>you will receive $1611.87 in benefit payments</strong>.

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -6,7 +6,7 @@ const Layout = require('../components/Layout.js')
 const ErrorList = require('../components/ErrorList.js')
 const LogoutLink = require('../components/LogoutLink.js')
 const SummaryTable = require('../components/SummaryTable.js')
-const Button = require('../components/forms/Button.js')
+const ButtonLink = require('../components/ButtonLink.js')
 
 const dashboard = css`
   position: relative;
@@ -60,13 +60,12 @@ const Dashboard = ({ data = {}, errors = {} }) =>
           Once your information is up-to-date, you will be ready to submit your tax return.
         </p>
         <p>
-          There are 3 sections in total, and it should take approximately
-          <strong>10 minutes</strong> to complete them.
+          There are <strong>3 sections</strong> in total, and it should take approximately
+          ${' '}<strong>10 minutes</strong>
+          ${' '}to complete.
         </p>
 
-        <form action="/confirmation">
-          <${Button} style=${submitButton}>Get started<//>
-        </form>
+        <${ButtonLink} href="/confirmation" style=${submitButton}>Get started<//>
       </div>
     <//>
   `

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -1,6 +1,7 @@
 const { css } = require('emotion')
 const { theme } = require('../styles.js')
 const { html } = require('../utils.js')
+const { getFirstName } = require('../api.js')
 const Layout = require('../components/Layout.js')
 const ErrorList = require('../components/ErrorList.js')
 const LogoutLink = require('../components/LogoutLink.js')
@@ -46,7 +47,7 @@ const Dashboard = ({ data = {}, errors = {} }) =>
 
       <div class=${dashboard}>
         <${LogoutLink} />
-        <h1>Dashboard</h1>
+        <h1>Hi, ${getFirstName(data.name)}</h1>
 
         <${SummaryTable} title="About you" rows=${aboutYouRows(data)} ifEditable=${false} //>
         <${SummaryTable} title="Your family" rows=${yourFamilyRows(data)} ifEditable=${false} //>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -20,14 +20,19 @@ const dashboard = css`
 const submitButton = css`
   width: 200px;
 `
-const makeRows = ({ name, address, maritalStatus, children, income }) => {
+const aboutYouRows = ({ name, address }) => {
+  return [{ key: 'Name', value: name }, { key: 'Mailing address', value: address }]
+}
+
+const yourFamilyRows = ({ maritalStatus, children }) => {
   return [
-    { key: 'Name', value: name },
-    { key: 'Mailing address', value: address },
     { key: 'Marital status', value: maritalStatus },
     { key: 'Number of children', value: children },
-    { key: 'Annual income', value: income },
   ]
+}
+
+const yourIncomeRows = ({ income }) => {
+  return [{ key: 'Annual income', value: income }]
 }
 
 const Dashboard = ({ data = {}, errors = {} }) =>
@@ -42,9 +47,10 @@ const Dashboard = ({ data = {}, errors = {} }) =>
       <div class=${dashboard}>
         <${LogoutLink} />
         <h1>Dashboard</h1>
-        <div>
-          <${SummaryTable} rows=${makeRows(data)} ifEditable=${false} //>
-        </div>
+
+        <${SummaryTable} title="About you" rows=${aboutYouRows(data)} ifEditable=${false} //>
+        <${SummaryTable} title="Your family" rows=${yourFamilyRows(data)} ifEditable=${false} //>
+        <${SummaryTable} title="Your income" rows=${yourIncomeRows(data)} ifEditable=${false} //>
 
         <p>
           Once you have provided your consent, go ahead and submit. (<a

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -6,8 +6,6 @@ const Layout = require('../components/Layout.js')
 const ErrorList = require('../components/ErrorList.js')
 const LogoutLink = require('../components/LogoutLink.js')
 const SummaryTable = require('../components/SummaryTable.js')
-const ValidationError = require('../components/forms/ValidationError.js')
-const Checkbox = require('../components/forms/Checkbox.js')
 const Button = require('../components/forms/Button.js')
 
 const dashboard = css`
@@ -48,25 +46,23 @@ const Dashboard = ({ data = {}, errors = {} }) =>
       <div class=${dashboard}>
         <${LogoutLink} />
         <h1>Hi, ${getFirstName(data.name)}</h1>
+        <p>
+        Here’s what we know about you based on your previous tax returns and information from your employer, BLORB CORP.
+        </p>
+        <p>If any of this information is wrong, you’ll have a chance to update it.</p>
 
         <${SummaryTable} title="About you" rows=${aboutYouRows(data)} ifEditable=${false} //>
         <${SummaryTable} title="Your family" rows=${yourFamilyRows(data)} ifEditable=${false} //>
         <${SummaryTable} title="Your income" rows=${yourIncomeRows(data)} ifEditable=${false} //>
 
         <p>
-          Once you have provided your consent, go ahead and submit. (<a
-            href="/consent"
-            target="_blank"
-            >Read more about consent.</a
-          >)
+        On the following pages, you can review each section and correct any outdated information.
+        Once your information is up-to-date, you will be ready to submit your tax return.
         </p>
-        <form method="post">
-          ${errors.consent &&
-            html`
-              <${ValidationError} ...${errors.consent} />
-            `}
-          <${Checkbox} id="consent">I totally consent to this<//>
-          <${Button} style=${submitButton}>Submit taxes<//>
+        <p>There are 3 sections in total, and it should take approximately <strong>10 minutes</strong> to complete them.</p>
+
+        <form action="/confirmation">
+          <${Button} style=${submitButton}>Get started<//>
         </form>
 
       </div>

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -37,7 +37,6 @@ const yourIncomeRows = ({ income }) => {
 const Dashboard = ({ data = {}, errors = {} }) =>
   html`
     <${Layout}>
-
       ${Object.keys(errors).length > 0 &&
         html`
           <${ErrorList} errors=${errors} //>
@@ -47,7 +46,8 @@ const Dashboard = ({ data = {}, errors = {} }) =>
         <${LogoutLink} />
         <h1>Hi, ${getFirstName(data.name)}</h1>
         <p>
-        Here’s what we know about you based on your previous tax returns and information from your employer, BLORB CORP.
+          Here’s what we know about you based on your previous tax returns and information from your
+          employer, BLORB CORP.
         </p>
         <p>If any of this information is wrong, you’ll have a chance to update it.</p>
 
@@ -56,17 +56,19 @@ const Dashboard = ({ data = {}, errors = {} }) =>
         <${SummaryTable} title="Your income" rows=${yourIncomeRows(data)} ifEditable=${false} //>
 
         <p>
-        On the following pages, you can review each section and correct any outdated information.
-        Once your information is up-to-date, you will be ready to submit your tax return.
+          On the following pages, you can review each section and correct any outdated information.
+          Once your information is up-to-date, you will be ready to submit your tax return.
         </p>
-        <p>There are 3 sections in total, and it should take approximately <strong>10 minutes</strong> to complete them.</p>
+        <p>
+          There are 3 sections in total, and it should take approximately
+          <strong>10 minutes</strong> to complete them.
+        </p>
 
         <form action="/confirmation">
           <${Button} style=${submitButton}>Get started<//>
         </form>
-
       </div>
-    </${Layout}>
+    <//>
   `
 
 module.exports = Dashboard

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -29,7 +29,7 @@ describe('<Dashboard>', () => {
     expect($('h1').text()).toEqual('Hi, Fred')
 
     expect($('button').length).toBe(1)
-    expect($('button').text()).toEqual('Submit taxes')
+    expect($('button').text()).toEqual('Get started')
 
     expect($('a[href="/logout"]').length).toBe(1)
     expect($('a[href="/logout"]').text()).toEqual('Log out')

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -15,6 +15,8 @@ describe('<Dashboard>', () => {
 
   const expectedStrings = Object.values(data)
 
+  const expectedH2s = ['About you', 'Your family', 'Your income']
+
   test('renders h1 as expected', () => {
     const $ = cheerio.load(
       render(
@@ -44,11 +46,24 @@ describe('<Dashboard>', () => {
       )
       expect($('h1').text()).toEqual('Dashboard')
 
+      expect($('dl').text()).toContain(str)
+    })
+  })
+
+  expectedH2s.map((str, i) => {
+    test(`renders h2 with "${str}"`, () => {
+      const $ = cheerio.load(
+        render(
+          html`
+            <${Dashboard} data=${data} />
+          `,
+        ),
+      )
       expect(
-        $('h1')
-          .next()
-          .html(),
-      ).toContain(str)
+        $('h2')
+          .eq(i)
+          .text(),
+      ).toEqual(str)
     })
   })
 })

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -28,8 +28,8 @@ describe('<Dashboard>', () => {
     expect($('h1').length).toBe(1)
     expect($('h1').text()).toEqual('Hi, Fred')
 
-    expect($('button').length).toBe(1)
-    expect($('button').text()).toEqual('Get started')
+    expect($('a.buttonLink').length).toBe(1)
+    expect($('a.buttonLink').text()).toEqual('Get started')
 
     expect($('a[href="/logout"]').length).toBe(1)
     expect($('a[href="/logout"]').text()).toEqual('Log out')

--- a/src/pages/__tests__/Dashboard.test.js
+++ b/src/pages/__tests__/Dashboard.test.js
@@ -26,7 +26,7 @@ describe('<Dashboard>', () => {
       ),
     )
     expect($('h1').length).toBe(1)
-    expect($('h1').text()).toEqual('Dashboard')
+    expect($('h1').text()).toEqual('Hi, Fred')
 
     expect($('button').length).toBe(1)
     expect($('button').text()).toEqual('Submit taxes')
@@ -44,7 +44,7 @@ describe('<Dashboard>', () => {
           `,
         ),
       )
-      expect($('h1').text()).toEqual('Dashboard')
+      expect($('h1').text()).toEqual('Hi, Fred')
 
       expect($('dl').text()).toContain(str)
     })

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -65,7 +65,7 @@ const renderPage = ({ locale, pageComponent, title = '', props }) => {
   return _renderDocument({
     title,
     locale,
-    content: renderStylesToString(content),
+    content,
   })
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -79,6 +79,7 @@ app.get('/dashboard', checkLogin, (req, res) => {
   res.send(
     renderPage({
       locale,
+      title: 'Your dashboard',
       pageComponent: 'Dashboard',
       props: { data },
     }),

--- a/src/styles.js
+++ b/src/styles.js
@@ -37,7 +37,27 @@ const visuallyHidden = css`
   white-space: nowrap !important;
 `
 
+const buttonStyles = css`
+  font: 400 1em sans-serif;
+  line-height: 1.1875;
+  display: inline-block;
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+  padding: 7px 10px;
+  border-radius: 0;
+  color: ${theme.color.black};
+  background-color: ${theme.color.green};
+  border: 2px solid ${theme.color.grey};
+  text-align: center;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-appearance: none;
+  text-decoration: none;
+`
+
 module.exports = {
   theme,
   visuallyHidden,
+  buttonStyles,
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -23,6 +23,12 @@ const theme = {
   },
 }
 
+const pageMargin = css`
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 ${theme.space.md};
+`
+
 const visuallyHidden = css`
   position: absolute !important;
   width: 1px !important;
@@ -60,4 +66,5 @@ module.exports = {
   theme,
   visuallyHidden,
   buttonStyles,
+  pageMargin,
 }


### PR DESCRIPTION
This PR brings the initial view (the dashboard page) in line with the one in the interaction flow.

Specifically:
- The page title contains the user's first name
- Added more personal data (they're stubs, but they're there)
- Added introductory paragraph and a "what to do now" paragraph
- removed the "consent" checkbox
- added a "Get started" button, which will eventually take someone to the next page (as yet unbuilt)
- *new*: Added a stub "Get help" link at the bottom in the footer

That's all for [this trello story](https://trello.com/c/kSY94sdj/34-online-confirmation-initial-view).

### screenshot


| before | after |
|--------|-------|
| ![localhost_3000_dashboard (1)](https://user-images.githubusercontent.com/2454380/56141368-af13e700-5f6a-11e9-85a0-05be3ba6b303.png)   |  ![cra-alpha-pr-24 herokuapp com_dashboard](https://user-images.githubusercontent.com/2454380/56225204-e6ec5e80-603e-11e9-8136-8311d7abd19e.png) |


