### PR TITLE
Don't save name to session on login page

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -53,7 +53,6 @@ app.get('/login', (req, res) => {
 app.post('/login', checkSchema(loginSchema), (req, res) => {
   let { name } = getSessionData(req.body)
   let user = API.getUser(name)
-  req.session = user || { name }
 
   const errors = validationResult(req)
   if (!user && !errors.isEmpty()) {
@@ -63,13 +62,14 @@ app.post('/login', checkSchema(loginSchema), (req, res) => {
         title: 'Error: Log in',
         pageComponent: 'Login',
         props: {
-          data: getSessionData(req.session),
+          data: { name },
           errors: errorArray2ErrorObject(errors),
         },
       }),
     )
   }
 
+  req.session = user
   res.redirect(302, '/dashboard')
 })
 


### PR DESCRIPTION
Only save a user to a session if a user has been found. 

Saving a name allowed us to pass back in the session to the page and see the name we just entered in the form field, but we could just pass it in directly and bypass the session altogether.

Good point by @sboisvert.