### PR TITLE
Revise the README after re-reading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This is a small frontend to trial user flows for a future CRA service that will help Canadians receive the benefits to which they are entitled.
 
-It's a server-side [express](https://expressjs.com/) application using [htm](https://github.com/developit/htm) to render out JSX-style components on the server.
+It's a server-side [express](https://expressjs.com/) application using [HTM](https://github.com/developit/htm) to render out JSX-style components on the server.
 
-## Getting started
+## Getting started (npm)
 
 ### [Install `npm`](https://www.npmjs.com/get-npm)
 
@@ -12,11 +12,8 @@ It's a server-side [express](https://expressjs.com/) application using [htm](htt
 
 `npm` will complain if you're not on node version `v10.15.0` or higher when you boot up the app.
 
-### [Install `docker`](https://docs.docker.com/install/)
 
-A docker container allows a developer to package up an application and all of its parts. This means we can build an app in any language, in any stack, and then run it anywhere — whether locally or on a server.
-
-## Build and run with npm
+### Build and run
 
 Guess what? There is **no build step**. Just install the dependencies and run it.
 
@@ -37,7 +34,7 @@ The app should be running at [http://localhost:3000/](http://localhost:3000/). W
 
 On a Mac, press `Control` + `C` to quit the running application.
 
-### Run tests with npm
+### Run tests
 
 ```bash
 # run unit tests
@@ -47,7 +44,14 @@ npm test
 npm run lint
 ```
 
-## Build and run as a Docker container
+## Using Docker
+
+
+### [Install `docker`](https://docs.docker.com/install/)
+
+A docker container allows a developer to package up an application and all of its parts. This means we can build an app in any language, in any stack, and then run it anywhere — whether locally or on a server.
+
+### Build and run as a Docker container
 
 ```bash
 # build an image locally
@@ -63,7 +67,7 @@ On a Mac, press `Control` + `C` to quit the running docker container.
 
 ## Resources
 
-As previously mentioned, this is a server-side [express](https://expressjs.com/) application using [htm](https://github.com/developit/htm) to render out JSX-style components on the server. Using htm as the view library is fairly cutting-edge, but otherwise this is a standard express application.
+As previously mentioned, this is a server-side [express](https://expressjs.com/) application using [HTM](https://github.com/developit/htm) to render out JSX-style components on the server. Using HTM as the view library is fairly cutting-edge, but otherwise this is a standard express application.
 
 ### express
 
@@ -75,7 +79,7 @@ As previously mentioned, this is a server-side [express](https://expressjs.com/)
 
 ### es6
 
-[ES6](https://www.makeuseof.com/tag/es6-javascript-programmers-need-know/) refers to version 6 of the ECMA Script programming language. It is a major enhancement to the JavaScript language, and adds many more features intended to make large-scale software development easier. Primarily, you should be familiar with **arrow function syntax**, **objects destructuring**, and **tagged template literals**.
+[ES6](https://www.makeuseof.com/tag/es6-javascript-programmers-need-know/) refers to version 6 of the ECMA Script programming language. It is a major enhancement to the JavaScript language, and adds many more features intended to make large-scale software development easier. Primarily, you should be familiar with **arrow function syntax**, **object destructuring**, and **tagged template literals**.
 
 [ES6 features](https://caniuse.com/#search=es6) are not supported by older browsers (eg, all versions of Internet Explorer), but, since we are only sending HTML to the browser, we don't need to worry about browser compatibility.
 
@@ -85,23 +89,23 @@ As previously mentioned, this is a server-side [express](https://expressjs.com/)
 - [Tagged Template literals on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
 
 
-### htm
+### HTM
 
 [Hyperscript Tagged Markup](https://github.com/developit/htm): JSX alternative using standard tagged templates, with compiler support.
 
-This application uses htm as a templating language. htm allows us to write components which are compiled on the server and served as HTML to the browser.
+This application uses HTM as a templating language. HTM allows us to write components which are compiled on the server and served as HTML to the browser.
 
-Components allow us to group related markup and CSS together, and the JSX-like syntax is a clean way to write self-contained slices of interface. Dedicated documentation for htm is fairly sparse, but if you understand [ES6 template literals](- [Tagged Template literals on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)) and are familiar with [JSX](https://reactjs.org/docs/introducing-jsx.html), then you're 95% of the way there.
+Components allow us to group related markup and CSS together, and the JSX-like syntax is a clean way to write self-contained slices of interface. Dedicated documentation for HTM is fairly sparse, but if you understand [ES6 template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) and are familiar with [JSX](https://reactjs.org/docs/introducing-jsx.html), then you're 95% of the way there.
 
-- [htm on GitHub](https://github.com/developit/htm)
-- [htm server-side demo by @timarney](https://github.com/timarney/htm-ssr-demo)
-- [htm server-side demo by @pcraig3](https://github.com/pcraig3/az-htm)
+- [HTM on GitHub](https://github.com/developit/htm)
+- [HTM server-side demo by @timarney](https://github.com/timarney/htm-ssr-demo)
+- [az-htm demo by @pcraig3](https://github.com/pcraig3/az-htm)
 
 ### JSX
 
-[JSX](https://www.reactenlightenment.com/react-jsx/5.1.html) is an XML/HTML-like syntax used by React that extends ECMAScript so that XML/HTML-like text can co-exist with JavaScript/React code. The syntax is intended to be used by preprocessors JSX syntax back into standard JavaScript so that browsers understand it.
+[JSX](https://www.reactenlightenment.com/react-jsx/5.1.html) is an HTML-like syntax used by React that extends ECMAScript so that HTML-like text can co-exist with JavaScript code. JSX needs to be (a) transpiled back to standard JavaScript, or, in our case (b) rendered out as HTML so that browsers understand it.
 
-In this application, we're not using JSX proper. Intead, we're using htm, which transforms JSX-like syntax into parseable HTML. However, understanding JSX is important for building out the views for this application.
+In this application, we're not using JSX proper, but, aside from some small differences, HTM is effectively the same thing. Therefore, understanding JSX syntax is important for building the views in this application.
 
 - [Introducing JSX on ReactJS.org](https://reactjs.org/docs/introducing-jsx.html)
 - [JSX In Depth on ReactJS.org](https://reactjs.org/docs/jsx-in-depth.html)


### PR DESCRIPTION
Moved out the Docker stuff because day-to-day, you don't really need it.
Also capitalized "HTM" because that's what the official repo does.

Otherwise, just some small fixes.