### PR TITLE
Remove "Alpha" page

### DIFF
--- a/src/__tests__/server.test.js
+++ b/src/__tests__/server.test.js
@@ -30,9 +30,4 @@ describe('Test server responses', () => {
     const response = await request(app).get('/consent')
     expect(response.text).toContain('<h1>Consent</h1>')
   })
-
-  test('it should return "Alpha" in the h1 tag for /alpha', async () => {
-    const response = await request(app).get('/alpha')
-    expect(response.text).toContain('<h1>Alpha</h1>')
-  })
 })

--- a/src/server.js
+++ b/src/server.js
@@ -145,14 +145,4 @@ app.get('/kim', (req, res) => {
   res.redirect(302, '/dashboard')
 })
 
-/* TODO: delete this by Monday, April 15th */
-app.get('/alpha', (req, res) => {
-  const content =
-    '<h1>Alpha</h1> \
-    <p>This site will be changing often as we learn from folks like you.</p> \
-    <p>[Full name]</p>'
-
-  res.send(_renderDocument({ title: 'Alpha', locale, content }))
-})
-
 module.exports = app


### PR DESCRIPTION
The very first story we had was to get an "Alpha" page up with a placeholder for user info. 

Now we've gotten a bit further and the Alpha page is just dead code. Also the comment says it should have been removed yesterday.