### PR TITLE
Add media queries to the theme object

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
 - 500 page
 - clean up the routes part of the server file
 - pass locale easily to any component
-- add media queries to styles.js
 - generic form edit pages
 - functional tests
 - pa11y tests
@@ -28,3 +27,4 @@
 - unit tests for all components
 - tests for redirects
 - an api-like thing for user data
+- add media queries to styles.js

--- a/src/components/AlphaBanner.js
+++ b/src/components/AlphaBanner.js
@@ -1,5 +1,5 @@
 const { css } = require('emotion')
-const { theme } = require('../styles.js')
+const { theme, mediaQueries } = require('../styles.js')
 const { html } = require('../utils.js')
 
 const alphaBanner = css`
@@ -18,7 +18,7 @@ const alphaBanner = css`
     font-weight: 700;
     display: inline-block;
     padding: 4px 8px;
-    padding-bottom: 1px;
+    padding-bottom: 3px;
     outline: 2px solid ${theme.color.black};
     outline-offset: -2px;
     color: #000;
@@ -33,6 +33,12 @@ const alphaBanner = css`
     display: table-cell;
     vertical-align: baseline;
   }
+
+  ${mediaQueries.sm(css`
+    p {
+      font-size: 0.75em;
+    }
+  `)};
 `
 
 const AlphaBanner = () =>

--- a/src/components/AlphaBanner.js
+++ b/src/components/AlphaBanner.js
@@ -1,5 +1,5 @@
 const { css } = require('emotion')
-const { theme, mediaQueries } = require('../styles.js')
+const { theme } = require('../styles.js')
 const { html } = require('../utils.js')
 
 const alphaBanner = css`
@@ -34,7 +34,7 @@ const alphaBanner = css`
     vertical-align: baseline;
   }
 
-  ${mediaQueries.sm(css`
+  ${theme.mq.sm(css`
     p {
       font-size: 0.75em;
     }

--- a/src/components/AlphaBanner.js
+++ b/src/components/AlphaBanner.js
@@ -34,11 +34,11 @@ const alphaBanner = css`
     vertical-align: baseline;
   }
 
-  ${theme.mq.sm(css`
+  @media (${theme.mq.sm}) {
     p {
       font-size: 0.75em;
     }
-  `)};
+  }
 `
 
 const AlphaBanner = () =>

--- a/src/components/ErrorList.js
+++ b/src/components/ErrorList.js
@@ -37,7 +37,7 @@ const errorList = css`
   }
 
   /* on larger screens */
-  @media (min-width: 640px) {
+  @media (${theme.mq.lg}) {
     border-width: 5px;
     margin-bottom: ${theme.space.xl};
     padding: ${theme.space.md};

--- a/src/components/LogoutLink.js
+++ b/src/components/LogoutLink.js
@@ -7,7 +7,7 @@ const logout = css`
   top: ${theme.space.md};
   right: 0;
 
-  @media (max-width: 640px) {
+  @media (${theme.mq.sm}) {
     top: ${theme.space.sm};
   }
 `

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -3,13 +3,11 @@ const { theme, visuallyHidden } = require('../styles.js')
 const { html } = require('../utils.js')
 
 const summaryRow = css`
-  /* on larger screens */
-  @media (min-width: 640px) {
+  @media (${theme.mq.lg}) {
     display: table-row;
   }
 
-  /* on smaller screens */
-  @media (max-width: 640px) {
+  @media (${theme.mq.sm}) {
     margin-bottom: ${theme.space.sm};
     border-bottom: 1px solid ${theme.color.grey};
   }
@@ -34,8 +32,7 @@ const summaryRow = css`
     margin-bottom: ${theme.space.sm};
   }
 
-  /* on larger screens */
-  @media (min-width: 640px) {
+  @media (${theme.mq.lg}) {
     .key,
     .value,
     .action {
@@ -61,8 +58,7 @@ const summaryRow = css`
     }
   }
 
-  /* on smaller screens */
-  @media (max-width: 640px) {
+  @media (${theme.mq.sm}) {
     .key {
       font-weight: 700;
     }

--- a/src/pages/Welcome.js
+++ b/src/pages/Welcome.js
@@ -23,8 +23,8 @@ const Welcome = ({ locale }) =>
         </ul>
 
         <p>
-          Then, you will see the information CRA has on file about you. If it is
-          up to date, you will be able to file your return immediately.
+          Then, you will see the information CRA has on file about you. If it is up to date, you
+          will be able to file your return immediately.
         </p>
 
         <a href="/login">Get started <span aria-hidden="true">→</span></a>

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,5 +1,6 @@
 const { renderStylesToString } = require('emotion-server')
 const render = require('preact-render-to-string')
+const { theme } = require('../styles.js')
 const { html, metaIfSHA } = require('../utils.js')
 
 const document = ({ title, locale, content }) => {
@@ -35,7 +36,7 @@ const document = ({ title, locale, content }) => {
             margin-bottom: 25px;
           }
 
-          @media (max-width: 640px) {
+          @media (${theme.mq.sm}) {
             body { font-size: 1.05em; }
           }
         </style>

--- a/src/styles.js
+++ b/src/styles.js
@@ -24,18 +24,8 @@ const theme = {
     xxl: '60px',
   },
   mq: {
-    sm: content =>
-      css`
-        @media screen and (max-width: 640px) {
-          ${content};
-        }
-      `,
-    lg: content =>
-      css`
-        @media screen and (min-width: 640px) {
-          ${content};
-        }
-      `,
+    sm: 'max-width: 640px',
+    lg: 'min-width: 640px',
   },
 }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,5 +1,7 @@
 const { css } = require('emotion')
 
+/* Utilities */
+
 const theme = {
   color: {
     grey: '#595959',
@@ -22,6 +24,23 @@ const theme = {
     xxl: '60px',
   },
 }
+
+const mediaQueries = {
+  sm: content =>
+    css`
+      @media screen and (max-width: 640px) {
+        ${content};
+      }
+    `,
+  lg: content =>
+    css`
+      @media screen and (min-width: 640px) {
+        ${content};
+      }
+    `,
+}
+
+/* Reused styles */
 
 const pageMargin = css`
   max-width: 900px;
@@ -64,6 +83,7 @@ const buttonStyles = css`
 
 module.exports = {
   theme,
+  mediaQueries,
   visuallyHidden,
   buttonStyles,
   pageMargin,

--- a/src/styles.js
+++ b/src/styles.js
@@ -23,21 +23,20 @@ const theme = {
     xl: '40px',
     xxl: '60px',
   },
-}
-
-const mediaQueries = {
-  sm: content =>
-    css`
-      @media screen and (max-width: 640px) {
-        ${content};
-      }
-    `,
-  lg: content =>
-    css`
-      @media screen and (min-width: 640px) {
-        ${content};
-      }
-    `,
+  mq: {
+    sm: content =>
+      css`
+        @media screen and (max-width: 640px) {
+          ${content};
+        }
+      `,
+    lg: content =>
+      css`
+        @media screen and (min-width: 640px) {
+          ${content};
+        }
+      `,
+  },
 }
 
 /* Reused styles */
@@ -83,7 +82,6 @@ const buttonStyles = css`
 
 module.exports = {
   theme,
-  mediaQueries,
   visuallyHidden,
   buttonStyles,
   pageMargin,


### PR DESCRIPTION
Keep all our breakpoints in the theme so that we have everything in one place. 

The impetus for this was actually that I thought the Alpha banner looked a bit shit on my phone.

| before | after |
|--------|-------|
|    text is <sub>small</sub>. bottom border is too close to words.  |   text is larger. bottom border padding improved.     |
|  ![cra-alpha azurewebsites net_](https://user-images.githubusercontent.com/2454380/56391444-a5a1ad80-61fc-11e9-8980-e140eba858e7.png)   |      ![localhost_3000_](https://user-images.githubusercontent.com/2454380/56391440-a33f5380-61fc-11e9-9795-b3adf65e41e9.png)  |



