### PR TITLE
Add form fields for editing personal information 

### DIFF
--- a/src/__tests__/session.test.js
+++ b/src/__tests__/session.test.js
@@ -70,7 +70,7 @@ it('It should log into the introduction with "/kim"', async () => {
   expect(response.headers['location']).toEqual('/introduction')
 })
 
-const authUrls = ['/introduction', '/edit', '/confirmation']
+const authUrls = ['/introduction', '/edit/name', '/confirmation']
 
 describe('Before logging in', () => {
   authUrls.map(url => {

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -1,7 +1,8 @@
 const { html } = require('../../utils.js')
 const { css } = require('emotion')
 const { theme, visuallyHidden } = require('../../styles.js')
-const Radio = require('./Radio')
+const Radio = require('./Radio.js')
+const ValidationError = require('./ValidationError.js')
 
 const fieldsetStyles = css`
   margin: 0;
@@ -21,6 +22,10 @@ const fieldsetStyles = css`
       margin: 0;
     }
   }
+
+  > div > div:last-of-type {
+    margin-bottom: 0;
+  }
 `
 
 const hideLegendStyles = css`
@@ -29,19 +34,38 @@ const hideLegendStyles = css`
   }
 `
 
+const errorStyles = css`
+  margin-left: -${theme.space.sm};
+  /* theme spacing minus border width */
+  padding-left: calc(${theme.space.sm} - 3px);
+  border-left: 3px solid ${theme.color.error};
+
+  [id$='-error'] {
+    margin-bottom: ${theme.space.md};
+  }
+`
+
 const makeRadio = ({ id, index, label, checked = false }) =>
   html`
     <${Radio} id=${`${id}-${index}`} name=${id} value=${label} checked=${checked}>${label}<//>
   `
-const Fieldset = ({ children, id, options = [], value = '', hideLegend = true }) =>
+
+const Fieldset = ({ children, id, options = [], value = '', hideLegend = true, error }) =>
   html`
     <fieldset
       id=${id}
-      class=${hideLegend ? `${fieldsetStyles} ${hideLegendStyles}` : fieldsetStyles}
+      class=${css`
+        ${fieldsetStyles} ${hideLegend && hideLegendStyles} ${error && errorStyles}
+      `}
+      aria-describedby=${error && `${id}-error`}
     >
       <legend>
         ${children}
       </legend>
+      ${error &&
+        html`
+          <${ValidationError} param=${error.param} msg=${error.msg} />
+        `}
       <div>
         ${options.map((label, index) => makeRadio({ id, index, label, checked: value === label }))}
       </div>

--- a/src/components/forms/Input.js
+++ b/src/components/forms/Input.js
@@ -32,9 +32,10 @@ const input = css`
   }
 `
 
-const withError = css`
-  margin-left: -12px;
-  padding-left: 12px;
+const errorStyles = css`
+  margin-left: -${theme.space.sm};
+  /* theme spacing minus border width */
+  padding-left: calc(${theme.space.sm} - 3px);
   border-left: 3px solid ${theme.color.error};
 `
 
@@ -90,7 +91,7 @@ const Input = ({ id, children, type = 'text', bold = true, error = undefined, ..
   html`
     <div
       class=${css`
-        ${input} ${error && withError}
+        ${input} ${error && errorStyles}
       `}
     >
       <label style=${{ fontWeight: !bold || bold === 'false' ? 400 : 700 }} for=${id}>

--- a/src/components/forms/Input.js
+++ b/src/components/forms/Input.js
@@ -86,24 +86,14 @@ const renderInput = ({ type, ...props }) =>
         <${TextInput} type=${type} ...${props} />
       `
 
-const Input = ({
-  id,
-  children,
-  type = 'text',
-  bold = true,
-  error = undefined,
-  ...props
-}) =>
+const Input = ({ id, children, type = 'text', bold = true, error = undefined, ...props }) =>
   html`
     <div
       class=${css`
         ${input} ${error && withError}
       `}
     >
-      <label
-        style=${{ fontWeight: !bold || bold === 'false' ? 400 : 700 }}
-        for=${id}
-      >
+      <label style=${{ fontWeight: !bold || bold === 'false' ? 400 : 700 }} for=${id}>
         ${children}
       </label>
       ${error &&

--- a/src/components/forms/__tests__/Fieldset.test.js
+++ b/src/components/forms/__tests__/Fieldset.test.js
@@ -37,6 +37,39 @@ describe('<Fieldset>', () => {
     ).toEqual('location-0')
   })
 
+  test('renders with a validation error', () => {
+    const error = { param: 'location', msg: 'Not a good option' }
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Fieldset} id="location" options=${['Option 1']} error=${error}
+            ><h1>Where do you live?</h1><//
+          >
+        `,
+      ),
+    )
+    expect($('fieldset').length).toBe(1)
+    expect($('fieldset legend h1').length).toBe(1)
+
+    expect($('span#location-error').length).toBe(1)
+    expect($('span#location-error').text()).toBe('Error: Not a good option')
+    expect($('fieldset').attr('aria-describedby')).toEqual('location-error')
+
+    // expect validation message is after the legend
+    expect(
+      $('legend')
+        .next()
+        .attr('id'),
+    ).toEqual('location-error')
+    // expect validation message is before the div containing the inputs
+    expect(
+      $('fieldset > div')
+        .prev()
+        .attr('id'),
+    ).toEqual('location-error')
+  })
+
   test('renders rows of radios', () => {
     const options = ['Zurich', 'St. Petersburg', 'Stockholm']
 

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -1,0 +1,64 @@
+const { css } = require('emotion')
+const { html } = require('../utils.js')
+const { theme } = require('../styles.js')
+const Layout = require('../components/Layout.js')
+const ErrorList = require('../components/ErrorList.js')
+const Input = require('../components/forms/Input.js')
+const Button = require('../components/forms/Button.js')
+
+const edit = css`
+  margin-top: ${theme.space.lg};
+
+  form {
+  }
+
+  form {
+    max-width: 480px;
+
+    > div {
+      margin-bottom: ${theme.space.xl};
+    }
+
+    label {
+      text-transform: capitalize;
+    }
+
+    button {
+      max-width: 150px;
+    }
+  }
+`
+
+const Edit = ({ id, description, type, data, errors = {} }) =>
+  html`
+    <${Layout}>
+      <div class=${edit}>
+        <a href="/dashboard"
+          ><span aria-hidden="true">←</span> Back to dashboard</a
+        >
+        ${Object.keys(errors).length > 0 &&
+          html`
+            <${ErrorList} errors=${errors} //>
+          `}
+
+        <h1>Edit ${id}</h1>
+        <p>${description}</p>
+
+        <form method="post">
+          <div>
+            <${Input}
+              id=${id}
+              type=${type}
+              value=${data[id]}
+              error=${errors[id]}
+              >${id}<//
+            >
+          </div>
+
+          <${Button}>Save<//>
+        </form>
+      </div>
+    <//>
+  `
+
+module.exports = Edit

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -27,7 +27,9 @@ const getFormField = ({ type, id, label, data, errors, options }) => {
   switch (type) {
     case 'radio':
       return html`
-        <${Fieldset} id=${id} options=${options} value=${data[id]}><h1>${label}</h1><//>
+        <${Fieldset} id=${id} options=${options} error=${errors[id]} value=${data[id]}
+          ><h1>${label}</h1><//
+        >
       `
 
     case 'number':

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -4,6 +4,7 @@ const { theme } = require('../styles.js')
 const Layout = require('../components/Layout.js')
 const ErrorList = require('../components/ErrorList.js')
 const Input = require('../components/forms/Input.js')
+const Fieldset = require('../components/forms/Fieldset.js')
 const Button = require('../components/forms/Button.js')
 
 const edit = css`
@@ -16,17 +17,31 @@ const edit = css`
       margin-bottom: ${theme.space.xl};
     }
 
-    label {
-      text-transform: capitalize;
-    }
-
     button {
       max-width: 150px;
     }
   }
 `
+/* eslint-disable indent */
+const getFormField = ({ type, id, label, data, errors, options }) => {
+  switch (type) {
+    case 'radio':
+      return html`
+        <${Fieldset} id=${id} options=${options} value=${data[id]}><h1>${label}</h1><//>
+      `
+    case 'textarea':
+    case 'text':
+      return html`
+        <${Input} id=${id} type=${type} value=${data[id]} error=${errors[id]}>${label}<//>
+      `
 
-const Edit = ({ id, label = '', description, type, previous, data, errors = {} }) =>
+    default:
+      throw new Error(`Error: Question type "${type}" not recognized`)
+  }
+}
+/* eslint-enable indent */
+
+const Edit = ({ label = '', description, type, previous, data, errors = {}, ...props }) =>
   html`
     <${Layout}>
       <div class=${edit}>
@@ -41,7 +56,7 @@ const Edit = ({ id, label = '', description, type, previous, data, errors = {} }
 
         <form method="post">
           <div>
-            <${Input} id=${id} type=${type} value=${data[id]} error=${errors[id]}>${label}<//>
+            ${getFormField({ type, label, data, errors, ...props })}
           </div>
 
           <${Button}>Save<//>

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -10,9 +10,6 @@ const edit = css`
   margin-top: ${theme.space.lg};
 
   form {
-  }
-
-  form {
     max-width: 480px;
 
     > div {
@@ -29,13 +26,11 @@ const edit = css`
   }
 `
 
-const Edit = ({ id, label = '', description, type, data, errors = {} }) =>
+const Edit = ({ id, label = '', description, type, previous, data, errors = {} }) =>
   html`
     <${Layout}>
       <div class=${edit}>
-        <a href="/dashboard"
-          ><span aria-hidden="true">←</span> Back to dashboard</a
-        >
+        <a href=${previous}><span aria-hidden="true">←</span> Back to previous page</a>
         ${Object.keys(errors).length > 0 &&
           html`
             <${ErrorList} errors=${errors} //>
@@ -46,13 +41,7 @@ const Edit = ({ id, label = '', description, type, data, errors = {} }) =>
 
         <form method="post">
           <div>
-            <${Input}
-              id=${id}
-              type=${type}
-              value=${data[id]}
-              error=${errors[id]}
-              >${label}<//
-            >
+            <${Input} id=${id} type=${type} value=${data[id]} error=${errors[id]}>${label}<//>
           </div>
 
           <${Button}>Save<//>

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -29,6 +29,13 @@ const getFormField = ({ type, id, label, data, errors, options }) => {
       return html`
         <${Fieldset} id=${id} options=${options} value=${data[id]}><h1>${label}</h1><//>
       `
+
+    case 'number':
+      return html`
+        <${Input} id=${id} type=${type} value=${data[id]} error=${errors[id]} style=${{ width: 50 }}
+          >${label}<//
+        >
+      `
     case 'textarea':
     case 'text':
       return html`

--- a/src/pages/Edit.js
+++ b/src/pages/Edit.js
@@ -29,7 +29,7 @@ const edit = css`
   }
 `
 
-const Edit = ({ id, description, type, data, errors = {} }) =>
+const Edit = ({ id, label = '', description, type, data, errors = {} }) =>
   html`
     <${Layout}>
       <div class=${edit}>
@@ -41,7 +41,7 @@ const Edit = ({ id, description, type, data, errors = {} }) =>
             <${ErrorList} errors=${errors} //>
           `}
 
-        <h1>Edit ${id}</h1>
+        <h1>Edit ${label.toLowerCase()}</h1>
         <p>${description}</p>
 
         <form method="post">
@@ -51,7 +51,7 @@ const Edit = ({ id, description, type, data, errors = {} }) =>
               type=${type}
               value=${data[id]}
               error=${errors[id]}
-              >${id}<//
+              >${label}<//
             >
           </div>
 

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -16,10 +16,10 @@ const form = css`
   > div {
     margin-bottom: ${theme.space.xl};
   }
-`
 
-const loginButton = css`
-  max-width: 150px;
+  button {
+    max-width: 150px;
+  }
 `
 
 /* eslint-disable no-irregular-whitespace */
@@ -39,7 +39,7 @@ const Login = ({ data: { name = '' } = {}, errors = {} }) =>
           <${Input} id="name" value=${name} error=${errors.name}>First name<//>
         </div>
 
-        <${Button} style=${loginButton}>Log in<//>
+        <${Button}>Log in<//>
       </form>
     <//>
   `

--- a/src/pages/YourFamily.js
+++ b/src/pages/YourFamily.js
@@ -8,7 +8,7 @@ const ButtonLink = require('../components/ButtonLink.js')
 const yourFamilyRows = ({ maritalStatus, children }) => {
   return [
     { key: 'Marital status', value: maritalStatus, id: 'maritalStatus' },
-    { key: 'Number of children', value: children },
+    { key: 'Number of children', value: children, id: 'children' },
   ]
 }
 

--- a/src/pages/YourFamily.js
+++ b/src/pages/YourFamily.js
@@ -7,7 +7,7 @@ const ButtonLink = require('../components/ButtonLink.js')
 
 const yourFamilyRows = ({ maritalStatus, children }) => {
   return [
-    { key: 'Marital status', value: maritalStatus },
+    { key: 'Marital status', value: maritalStatus, id: 'maritalStatus' },
     { key: 'Number of children', value: children },
   ]
 }

--- a/src/questions/address.js
+++ b/src/questions/address.js
@@ -10,6 +10,7 @@ module.exports = {
         errorMessage: 'Mailing address can’t be empty',
         negated: true,
       },
+      trim: true,
     },
   },
   previous: '/about-you',

--- a/src/questions/address.js
+++ b/src/questions/address.js
@@ -1,0 +1,15 @@
+module.exports = {
+  id: 'address',
+  label: 'Mailing address',
+  description: 'Please enter your current mailing address.',
+  type: 'textarea',
+  schema: {
+    address: {
+      in: ['body'],
+      isEmpty: {
+        errorMessage: 'Mailing address can’t be empty',
+        negated: true,
+      },
+    },
+  },
+}

--- a/src/questions/address.js
+++ b/src/questions/address.js
@@ -12,4 +12,5 @@ module.exports = {
       },
     },
   },
+  previous: '/about-you',
 }

--- a/src/questions/children.js
+++ b/src/questions/children.js
@@ -14,6 +14,7 @@ module.exports = {
         errorMessage: 'Number of children must be 0 or higher',
         options: { min: 0 },
       },
+      trim: true,
     },
   },
   previous: '/your-family',

--- a/src/questions/children.js
+++ b/src/questions/children.js
@@ -1,0 +1,20 @@
+module.exports = {
+  id: 'children',
+  label: 'Number of children',
+  description: 'Please enter the number of children you have as dependents.',
+  type: 'number',
+  schema: {
+    children: {
+      in: ['body'],
+      isEmpty: {
+        errorMessage: 'Number of children can’t be empty',
+        negated: true,
+      },
+      isInt: {
+        errorMessage: 'Number of children must be 0 or higher',
+        options: { min: 0 },
+      },
+    },
+  },
+  previous: '/your-family',
+}

--- a/src/questions/maritalStatus.js
+++ b/src/questions/maritalStatus.js
@@ -1,0 +1,23 @@
+const options = ['Married', 'Living common-law', 'Widowed', 'Divorced', 'Separated', 'Single']
+
+module.exports = {
+  id: 'maritalStatus',
+  label: 'Marital status',
+  description: 'Please enter your marital status as of December 31, 2018.',
+  type: 'radio',
+  options: options,
+  schema: {
+    maritalStatus: {
+      in: ['body'],
+      isEmpty: {
+        errorMessage: 'Marital status can’t be empty',
+        negated: true,
+      },
+      isIn: {
+        errorMessage: 'Marital status must be one of the provided options',
+        options: [options],
+      },
+    },
+  },
+  previous: '/your-family',
+}

--- a/src/questions/maritalStatus.js
+++ b/src/questions/maritalStatus.js
@@ -17,6 +17,7 @@ module.exports = {
         errorMessage: 'Marital status must be one of the provided options',
         options: [options],
       },
+      trim: true,
     },
   },
   previous: '/your-family',

--- a/src/questions/name.js
+++ b/src/questions/name.js
@@ -1,5 +1,6 @@
-const name = {
+module.exports = {
   id: 'name',
+  label: 'Full name',
   description: 'Please enter your full name.',
   type: 'text',
   schema: {
@@ -12,5 +13,3 @@ const name = {
     },
   },
 }
-
-module.exports = name

--- a/src/questions/name.js
+++ b/src/questions/name.js
@@ -1,0 +1,16 @@
+const name = {
+  id: 'name',
+  description: 'Please enter your full name.',
+  type: 'text',
+  schema: {
+    name: {
+      in: ['body'],
+      isEmpty: {
+        errorMessage: 'Name can’t be empty',
+        negated: true,
+      },
+    },
+  },
+}
+
+module.exports = name

--- a/src/questions/name.js
+++ b/src/questions/name.js
@@ -10,6 +10,7 @@ module.exports = {
         errorMessage: 'Name can’t be empty',
         negated: true,
       },
+      trim: true,
     },
   },
   previous: '/about-you',

--- a/src/questions/name.js
+++ b/src/questions/name.js
@@ -12,4 +12,5 @@ module.exports = {
       },
     },
   },
+  previous: '/about-you',
 }

--- a/src/server.js
+++ b/src/server.js
@@ -132,6 +132,50 @@ app.get('/edit', checkLogin, (req, res) => {
   res.send(_renderDocument({ title: '[WIP] Edit', locale, content }))
 })
 
+app.get('/edit/name', checkLogin, (req, res) => {
+  const name = require('./questions/name.js')
+
+  res.send(
+    renderPage({
+      locale,
+      pageComponent: 'Edit',
+      props: {
+        ...name,
+        data: getSessionData(req.session),
+      },
+    }),
+  )
+})
+
+const pickEditSchema = (req, res, next) => {
+  const question = require(`./questions/${req.params.id}.js`)
+  return checkSchema(question.schema)[0](req, res, next)
+}
+
+app.post('/edit/:id', checkLogin, pickEditSchema, (req, res) => {
+  const question = require(`./questions/${req.params.id}.js`)
+
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(422).send(
+      renderPage({
+        locale,
+        title: 'Error: Edit',
+        pageComponent: 'Edit',
+        props: {
+          ...question,
+          data: getSessionData(req.session),
+          errors: errorArray2ErrorObject(errors),
+        },
+      }),
+    )
+  }
+
+  // update session with new value
+  req.session[req.params.id] = req.body[req.params.id]
+  return res.redirect(302, '/dashboard')
+})
+
 app.get('/confirmation', checkLogin, (req, res) => {
   const data = getSessionData(req.session)
 

--- a/src/server.js
+++ b/src/server.js
@@ -132,15 +132,15 @@ app.get('/edit', checkLogin, (req, res) => {
   res.send(_renderDocument({ title: '[WIP] Edit', locale, content }))
 })
 
-app.get('/edit/name', checkLogin, (req, res) => {
-  const name = require('./questions/name.js')
+app.get('/edit/:id(name|address)?', checkLogin, (req, res) => {
+  const question = require(`./questions/${req.params.id}.js`)
 
   res.send(
     renderPage({
       locale,
       pageComponent: 'Edit',
       props: {
-        ...name,
+        ...question,
         data: getSessionData(req.session),
       },
     }),

--- a/src/server.js
+++ b/src/server.js
@@ -138,6 +138,7 @@ app.get('/edit/:id(name|address|maritalStatus|children)?', checkLogin, (req, res
   res.send(
     renderPage({
       locale,
+      title: `Edit ${question.label.toLowerCase()}`,
       pageComponent: 'Edit',
       props: {
         ...question,
@@ -164,7 +165,7 @@ app.post(
       return res.status(422).send(
         renderPage({
           locale,
-          title: 'Error: Edit',
+          title: `Error: Edit ${question.label.toLowerCase()}`,
           pageComponent: 'Edit',
           props: {
             ...question,

--- a/src/server.js
+++ b/src/server.js
@@ -132,7 +132,7 @@ app.get('/edit', checkLogin, (req, res) => {
   res.send(_renderDocument({ title: '[WIP] Edit', locale, content }))
 })
 
-app.get('/edit/:id(name|address|maritalStatus)?', checkLogin, (req, res) => {
+app.get('/edit/:id(name|address|maritalStatus|children)?', checkLogin, (req, res) => {
   const question = require(`./questions/${req.params.id}.js`)
 
   res.send(
@@ -152,29 +152,34 @@ const pickEditSchema = (req, res, next) => {
   return checkSchema(question.schema)[0](req, res, next)
 }
 
-app.post('/edit/:id', checkLogin, pickEditSchema, (req, res) => {
-  const question = require(`./questions/${req.params.id}.js`)
+app.post(
+  '/edit/:id(name|address|maritalStatus|children)?',
+  checkLogin,
+  pickEditSchema,
+  (req, res) => {
+    const question = require(`./questions/${req.params.id}.js`)
 
-  const errors = validationResult(req)
-  if (!errors.isEmpty()) {
-    return res.status(422).send(
-      renderPage({
-        locale,
-        title: 'Error: Edit',
-        pageComponent: 'Edit',
-        props: {
-          ...question,
-          data: getSessionData(req.session),
-          errors: errorArray2ErrorObject(errors),
-        },
-      }),
-    )
-  }
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+      return res.status(422).send(
+        renderPage({
+          locale,
+          title: 'Error: Edit',
+          pageComponent: 'Edit',
+          props: {
+            ...question,
+            data: getSessionData(req.session),
+            errors: errorArray2ErrorObject(errors),
+          },
+        }),
+      )
+    }
 
-  // update session with new value
-  req.session[req.params.id] = req.body[req.params.id]
-  return res.redirect(302, question.previous)
-})
+    // update session with new value
+    req.session[req.params.id] = req.body[req.params.id]
+    return res.redirect(302, question.previous)
+  },
+)
 
 app.get('/confirmation', checkLogin, (req, res) => {
   const data = getSessionData(req.session)

--- a/src/server.js
+++ b/src/server.js
@@ -132,7 +132,7 @@ app.get('/edit', checkLogin, (req, res) => {
   res.send(_renderDocument({ title: '[WIP] Edit', locale, content }))
 })
 
-app.get('/edit/:id(name|address)?', checkLogin, (req, res) => {
+app.get('/edit/:id(name|address|maritalStatus)?', checkLogin, (req, res) => {
   const question = require(`./questions/${req.params.id}.js`)
 
   res.send(

--- a/src/server.js
+++ b/src/server.js
@@ -122,16 +122,7 @@ app.get('/T4', (req, res) => {
   )
 })
 
-app.get('/edit', checkLogin, (req, res) => {
-  const content = `
-    <h1>Editing coming soon</h1>
-    <p>Editing isn’t working yet, so for now you have to print out this website, change your info, and then mail it to Nancy McKenna.</p>
-    <a href="/introduction">← Go back</a>
-    `
-
-  res.send(_renderDocument({ title: '[WIP] Edit', locale, content }))
-})
-
+// Whitelist only specific routes (eg, https://stackoverflow.com/a/15350845)
 app.get('/edit/:id(name|address|maritalStatus|children)?', checkLogin, (req, res) => {
   const question = require(`./questions/${req.params.id}.js`)
 
@@ -153,6 +144,7 @@ const pickEditSchema = (req, res, next) => {
   return checkSchema(question.schema)[0](req, res, next)
 }
 
+// Whitelist only specific routes (eg, https://stackoverflow.com/a/15350845)
 app.post(
   '/edit/:id(name|address|maritalStatus|children)?',
   checkLogin,

--- a/src/server.js
+++ b/src/server.js
@@ -173,7 +173,7 @@ app.post('/edit/:id', checkLogin, pickEditSchema, (req, res) => {
 
   // update session with new value
   req.session[req.params.id] = req.body[req.params.id]
-  return res.redirect(302, '/dashboard')
+  return res.redirect(302, question.previous)
 })
 
 app.get('/confirmation', checkLogin, (req, res) => {


### PR DESCRIPTION
This pull request adds the ability to edit the first 4 fields: name, address, marital status, and number of children. (Note: adding the form elements themselves was merged as part of #33 and #39.)

It's a fairly naive implementation: editing is super simplified, but it meets the requirements of the ["Change information"](https://trello.com/c/cGCpHSIV/36-online-confirmation-information-change) story, and it's something we can build out further as needed. 

It's also pretty accessible, following many of the guidelines of the [GOV.UK design system](https://design-system.service.gov.uk/):

- [One thing per page](https://designnotes.blog.gov.uk/2015/07/03/one-thing-per-page/)
- [Text inputs](https://design-system.service.gov.uk/components/text-input/)
- [Textareas](https://design-system.service.gov.uk/components/textarea/)
- [Radio buttons](https://design-system.service.gov.uk/components/radios/)
- [Error messages](https://design-system.service.gov.uk/components/error-message/)
- [Error summaries](https://design-system.service.gov.uk/components/error-summary/)

I'm sure this will change as we move forwards and find out more about what values we are likely to be able to change, but it's simple enough to start with and gets us going in the right direction.

## gif

![forms](https://user-images.githubusercontent.com/2454380/56738200-1c2d3680-673a-11e9-97d7-151903f54be0.gif)

