### PR TITLE
Add base form elements needed for edit fields

### DIFF
--- a/cypress/integration/full_run.spec.js
+++ b/cypress/integration/full_run.spec.js
@@ -33,8 +33,8 @@ describe('Full run through', function() {
         .should('contain', 'Log in')
         .click()
 
-      // DASHBOARD PAGE
-      cy.url().should('contain', '/dashboard')
+      // INTRODUCTION PAGE
+      cy.url().should('contain', '/introduction')
       cy.get('h1').should('contain', `Hi, ${getFirstName(user.name)}`)
 
       cy.get('h2')

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -68,7 +68,7 @@ const summaryRow = css`
     }
   }
 `
-const SummaryRow = ({ row: { key, value } = {}, ifEditable = true }) => {
+const SummaryRow = ({ row: { key, value, id = false } = {} }) => {
   return html`
     <div class=${summaryRow}>
       <dt class="key">
@@ -77,11 +77,10 @@ const SummaryRow = ({ row: { key, value } = {}, ifEditable = true }) => {
       <dd class="value">
         ${value}
       </dd>
-      ${ifEditable &&
-        ifEditable !== 'false' &&
+      ${id &&
         html`
           <dd class="action">
-            <a href="/edit">
+            <a href=${`/edit/${id}`}>
               Change
               <span class="${visuallyHidden}">${` ${key && key.toLowerCase()}`}</span>
             </a>

--- a/src/components/__tests__/SummaryTable.test.js
+++ b/src/components/__tests__/SummaryTable.test.js
@@ -45,49 +45,68 @@ describe('<SummaryTable>', () => {
     expect($('h2').text()).toEqual('About you')
   })
 
-  test('renders correct cells with 1 row', () => {
-    const $ = renderTable({ rows })
+  describe('it renders cells with 1 row', () => {
+    test('INCLUDING edit links', () => {
+      let rowsWithId = [{ key: 'Full name', value: 'Fred Smith', id: 'name' }]
 
-    // first row
-    expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual(
-      'Full name',
-    )
-    expect(getCell({ cheerio: $, rowNum: 0, find: '.value' }).text()).toEqual(
-      'Fred Smith',
-    )
-    expect(getCell({ cheerio: $, rowNum: 0, find: '.action' }).text()).toEqual(
-      'Change full name',
-    )
-    expect(
-      getCell({ cheerio: $, rowNum: 0, find: '.action a' }).attr('href'),
-    ).toEqual('/edit')
+      const $ = renderTable({ rows: rowsWithId })
+
+      // first row
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.value' }).text()).toEqual('Fred Smith')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.action' }).text()).toEqual('Change full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.action a' }).attr('href')).toEqual(
+        '/edit/name',
+      )
+    })
+
+    test('EXCLUDING edit links', () => {
+      let rowsNoId = rows
+
+      const $ = renderTable({ rows: rowsNoId })
+
+      // first row
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.value' }).text()).toEqual('Fred Smith')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.action' }).length).toBe(0)
+    })
   })
 
-  test('renders correct cells with 2 rows', () => {
-    let moreRows = rows.concat([{ key: 'Date of birth', value: '18-06-1971' }])
-    const $ = renderTable({ rows: moreRows })
+  describe('it renders cells with 2 rows', () => {
+    test('INCLUDING edit links', () => {
+      let rowsWithId = [
+        { key: 'Full name', value: 'Fred Smith', id: 'name' },
+        { key: 'Date of birth', value: '18-06-1971', id: 'dob' },
+      ]
 
-    // second row
-    expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual(
-      'Date of birth',
-    )
-    expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual(
-      '18-06-1971',
-    )
-    expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).text()).toEqual(
-      'Change date of birth',
-    )
-    expect(
-      getCell({ cheerio: $, rowNum: 1, find: '.action a' }).attr('href'),
-    ).toEqual('/edit')
-  })
+      const $ = renderTable({ rows: rowsWithId })
 
-  test('renders without change links', () => {
-    let moreRows = rows.concat([{ key: 'Date of birth', value: '18-06-1971' }])
-    const $ = renderTable({ rows: moreRows, ifEditable: false })
+      // first row
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
 
-    expect($('.action').length).toBe(0)
-    expect($.html()).not.toContain('Change date of birth')
-    expect($.html()).not.toContain('Change full name')
+      // second row
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual('Date of birth')
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual('18-06-1971')
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).text()).toEqual(
+        'Change date of birth',
+      )
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.action a' }).attr('href')).toEqual(
+        '/edit/dob',
+      )
+    })
+
+    test('EXCLUDING edit links', () => {
+      let rowsNoId = rows.concat([{ key: 'Date of birth', value: '18-06-1971' }])
+
+      const $ = renderTable({ rows: rowsNoId })
+
+      // first row
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+
+      // second row
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual('Date of birth')
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual('18-06-1971')
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).length).toBe(0)
+    })
   })
 })

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -23,17 +23,19 @@ const fieldsetStyles = css`
   }
 `
 
-const Fieldset = ({ children, id }) =>
+const makeRadio = ({ id, index, row: { key, value } = {} }) =>
+  html`
+    <${Radio} id=${`${id}-${index}`} name=${id} value=${value}>${key}<//>
+  `
+
+const Fieldset = ({ children, id, rows = [] }) =>
   html`
     <fieldset id=${id} class=${fieldsetStyles}>
       <legend>
         ${children}
       </legend>
       <div>
-        <${Radio} id=${`${id}-1`} name=${id} value="england">England<//>
-        <${Radio} id=${`${id}-2`} name=${id} value="scotland">Scotland<//>
-        <${Radio} id=${`${id}-3`} name=${id} value="wales">Wales<//>
-        <${Radio} id=${`${id}-4`} name=${id} value="northern-ireland">Northern Ireland<//>
+        ${rows.map((row, index) => makeRadio({ id, index, row }))}
       </div>
     </fieldset>
   `

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -1,0 +1,43 @@
+const { html } = require('../../utils.js')
+const { css } = require('emotion')
+const { theme } = require('../../styles.js')
+const Radio = require('./Radio')
+
+const fieldsetStyles = css`
+  margin: 0;
+  padding: 0;
+  border: 0;
+
+  legend {
+    box-sizing: border-box;
+    display: table;
+    max-width: 100%;
+    margin-bottom: ${theme.space.sm};
+    padding: 0;
+    overflow: hidden;
+    white-space: normal;
+
+    * {
+      margin: 0;
+    }
+  }
+`
+
+const Fieldset = ({ children }) =>
+  html`
+    <fieldset class=${fieldsetStyles}>
+      <legend>
+        ${children}
+      </legend>
+      <div>
+        <${Radio} id="where-do-you-live-1" name="where-do-you-live" value="england">England<//>
+        <${Radio} id="where-do-you-live-2" name="where-do-you-live" value="scotland">Scotland<//>
+        <${Radio} id="where-do-you-live-3" name="where-do-you-live" value="wales">Wales<//>
+        <${Radio} id="where-do-you-live-4" name="where-do-you-live" value="northern-ireland"
+          >Northern Ireland<//
+        >
+      </div>
+    </fieldset>
+  `
+
+module.exports = Fieldset

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -23,19 +23,19 @@ const fieldsetStyles = css`
   }
 `
 
-const makeRadio = ({ id, index, row: { key, value } = {}, checked = false }) =>
+const makeRadio = ({ id, index, label, checked = false }) =>
   html`
-    <${Radio} id=${`${id}-${index}`} name=${id} value=${value} checked=${checked}>${key}<//>
+    <${Radio} id=${`${id}-${index}`} name=${id} value=${label} checked=${checked}>${label}<//>
   `
 
-const Fieldset = ({ children, id, rows = [], value = '' }) =>
+const Fieldset = ({ children, id, options = [], value = '' }) =>
   html`
     <fieldset id=${id} class=${fieldsetStyles}>
       <legend>
         ${children}
       </legend>
       <div>
-        ${rows.map((row, index) => makeRadio({ id, index, row, checked: value === row.value }))}
+        ${options.map((label, index) => makeRadio({ id, index, label, checked: value === label }))}
       </div>
     </fieldset>
   `

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -23,19 +23,17 @@ const fieldsetStyles = css`
   }
 `
 
-const Fieldset = ({ children }) =>
+const Fieldset = ({ children, id }) =>
   html`
-    <fieldset class=${fieldsetStyles}>
+    <fieldset id=${id} class=${fieldsetStyles}>
       <legend>
         ${children}
       </legend>
       <div>
-        <${Radio} id="where-do-you-live-1" name="where-do-you-live" value="england">England<//>
-        <${Radio} id="where-do-you-live-2" name="where-do-you-live" value="scotland">Scotland<//>
-        <${Radio} id="where-do-you-live-3" name="where-do-you-live" value="wales">Wales<//>
-        <${Radio} id="where-do-you-live-4" name="where-do-you-live" value="northern-ireland"
-          >Northern Ireland<//
-        >
+        <${Radio} id=${`${id}-1`} name=${id} value="england">England<//>
+        <${Radio} id=${`${id}-2`} name=${id} value="scotland">Scotland<//>
+        <${Radio} id=${`${id}-3`} name=${id} value="wales">Wales<//>
+        <${Radio} id=${`${id}-4`} name=${id} value="northern-ireland">Northern Ireland<//>
       </div>
     </fieldset>
   `

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -1,6 +1,6 @@
 const { html } = require('../../utils.js')
 const { css } = require('emotion')
-const { theme } = require('../../styles.js')
+const { theme, visuallyHidden } = require('../../styles.js')
 const Radio = require('./Radio')
 
 const fieldsetStyles = css`
@@ -27,11 +27,10 @@ const makeRadio = ({ id, index, label, checked = false }) =>
   html`
     <${Radio} id=${`${id}-${index}`} name=${id} value=${label} checked=${checked}>${label}<//>
   `
-
-const Fieldset = ({ children, id, options = [], value = '' }) =>
+const Fieldset = ({ children, id, options = [], value = '', hideLegend = true }) =>
   html`
     <fieldset id=${id} class=${fieldsetStyles}>
-      <legend>
+      <legend class=${hideLegend && visuallyHidden}>
         ${children}
       </legend>
       <div>

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -23,19 +23,19 @@ const fieldsetStyles = css`
   }
 `
 
-const makeRadio = ({ id, index, row: { key, value } = {} }) =>
+const makeRadio = ({ id, index, row: { key, value } = {}, checked = false }) =>
   html`
-    <${Radio} id=${`${id}-${index}`} name=${id} value=${value}>${key}<//>
+    <${Radio} id=${`${id}-${index}`} name=${id} value=${value} checked=${checked}>${key}<//>
   `
 
-const Fieldset = ({ children, id, rows = [] }) =>
+const Fieldset = ({ children, id, rows = [], value = '' }) =>
   html`
     <fieldset id=${id} class=${fieldsetStyles}>
       <legend>
         ${children}
       </legend>
       <div>
-        ${rows.map((row, index) => makeRadio({ id, index, row }))}
+        ${rows.map((row, index) => makeRadio({ id, index, row, checked: value === row.value }))}
       </div>
     </fieldset>
   `

--- a/src/components/forms/Fieldset.js
+++ b/src/components/forms/Fieldset.js
@@ -23,14 +23,23 @@ const fieldsetStyles = css`
   }
 `
 
+const hideLegendStyles = css`
+  legend {
+    ${visuallyHidden};
+  }
+`
+
 const makeRadio = ({ id, index, label, checked = false }) =>
   html`
     <${Radio} id=${`${id}-${index}`} name=${id} value=${label} checked=${checked}>${label}<//>
   `
 const Fieldset = ({ children, id, options = [], value = '', hideLegend = true }) =>
   html`
-    <fieldset id=${id} class=${fieldsetStyles}>
-      <legend class=${hideLegend && visuallyHidden}>
+    <fieldset
+      id=${id}
+      class=${hideLegend ? `${fieldsetStyles} ${hideLegendStyles}` : fieldsetStyles}
+    >
+      <legend>
         ${children}
       </legend>
       <div>

--- a/src/components/forms/Input.js
+++ b/src/components/forms/Input.js
@@ -9,15 +9,20 @@ const input = css`
     margin-bottom: ${theme.space.xs};
   }
 
-  input {
+  input,
+  textarea {
     font: 400 1em sans-serif;
     border: 2px solid ${theme.color.black};
     width: 100%;
-    height: 40px;
     margin-top: 0;
     padding: 5px;
     border-radius: 0;
     -webkit-appearance: none;
+    vertical-align: top;
+  }
+
+  input {
+    height: 40px;
 
     &[type='number']::-webkit-inner-spin-button,
     &[type='number']::-webkit-outer-spin-button {
@@ -42,22 +47,50 @@ const TextInput = ({
   ...props
 }) => html`
   <input
-    style=${{ ...style }}
     id=${id}
     name=${name || id}
     type=${type}
+    style=${{ ...style }}
     aria-describedby="${error ? `${error.param}-error` : false}}"
     ...${props}
   />
 `
 
+const TextArea = ({
+  id,
+  name = '',
+  style = {},
+  value = '',
+  error = undefined,
+  rows = 5,
+  ...props
+}) => html`
+  <textarea
+    id=${id}
+    name=${name || id}
+    rows=${rows}
+    style=${{ ...style }}
+    aria-describedby="${error ? `${error.param}-error` : false}}"
+    ...${props}
+  >
+${value}</textarea
+  >
+`
+
+const renderInput = ({ type, ...props }) =>
+  type === 'textarea'
+    ? html`
+        <${TextArea} ...${props} />
+      `
+    : html`
+        <${TextInput} type=${type} ...${props} />
+      `
+
 const Input = ({
   id,
   children,
-  name = '',
   type = 'text',
   bold = true,
-  style = {},
   error = undefined,
   ...props
 }) =>
@@ -77,14 +110,7 @@ const Input = ({
         html`
           <${ValidationError} param=${error.param} msg=${error.msg} />
         `}
-      <${TextInput}
-        id=${id}
-        style=${style}
-        type=${type}
-        name=${name}
-        error=${error}
-        ...${props}
-      />
+      ${renderInput({ type, id, error, ...props })}
     </div>
   `
 

--- a/src/components/forms/Input.js
+++ b/src/components/forms/Input.js
@@ -4,8 +4,6 @@ const { html } = require('../../utils.js')
 const ValidationError = require('./ValidationError')
 
 const input = css`
-  display: block;
-
   label {
     display: block;
     margin-bottom: ${theme.space.xs};
@@ -35,6 +33,24 @@ const withError = css`
   border-left: 3px solid ${theme.color.error};
 `
 
+const TextInput = ({
+  id,
+  name = '',
+  type = 'text',
+  style = {},
+  error = undefined,
+  ...props
+}) => html`
+  <input
+    style=${{ ...style }}
+    id=${id}
+    name=${name || id}
+    type=${type}
+    aria-describedby="${error ? `${error.param}-error` : false}}"
+    ...${props}
+  />
+`
+
 const Input = ({
   id,
   children,
@@ -46,7 +62,7 @@ const Input = ({
   ...props
 }) =>
   html`
-    <span
+    <div
       class=${css`
         ${input} ${error && withError}
       `}
@@ -61,15 +77,15 @@ const Input = ({
         html`
           <${ValidationError} param=${error.param} msg=${error.msg} />
         `}
-      <input
-        style=${{ ...style }}
+      <${TextInput}
         id=${id}
-        name=${name || id}
+        style=${style}
         type=${type}
-        aria-describedby="${error ? `${error.param}-error` : false}}"
+        name=${name}
+        error=${error}
         ...${props}
       />
-    </span>
+    </div>
   `
 
 module.exports = Input

--- a/src/components/forms/Radio.js
+++ b/src/components/forms/Radio.js
@@ -8,7 +8,7 @@ const radioStyles = css`
   display: block;
   position: relative;
   min-height: ${theme.space.xl};
-  margin-bottom: ${theme.space.xl};
+  margin-bottom: ${theme.space.sm};
   padding: 0 0 0 ${theme.space.xl};
   clear: left;
 

--- a/src/components/forms/ValidationError.js
+++ b/src/components/forms/ValidationError.js
@@ -3,7 +3,7 @@ const { theme, visuallyHidden } = require('../../styles.js')
 const { html } = require('../../utils.js')
 
 const validationError = css`
-  display: inline-block;
+  display: block;
   margin-bottom: 10px;
   color: ${theme.color.error};
 `

--- a/src/components/forms/__tests__/Fieldset.test.js
+++ b/src/components/forms/__tests__/Fieldset.test.js
@@ -17,4 +17,23 @@ describe('<Fieldset>', () => {
     expect($('fieldset legend h1').length).toBe(1)
     expect($('fieldset legend h1').text()).toEqual('Where do you live?')
   })
+
+  test('renders with passed-in attributes', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Fieldset} id="location"><h1>Where do you live?</h1><//>
+        `,
+      ),
+    )
+    expect($('fieldset').length).toBe(1)
+    expect($('fieldset legend h1').length).toBe(1)
+
+    expect($('fieldset').attr('id')).toEqual('location')
+    expect(
+      $('fieldset input')
+        .first()
+        .attr('id'),
+    ).toEqual('location-1')
+  })
 })

--- a/src/components/forms/__tests__/Fieldset.test.js
+++ b/src/components/forms/__tests__/Fieldset.test.js
@@ -22,9 +22,7 @@ describe('<Fieldset>', () => {
     const $ = cheerio.load(
       render(
         html`
-          <${Fieldset} id="location" rows=${[{ key: 'r1', value: 'r1' }]}
-            ><h1>Where do you live?</h1><//
-          >
+          <${Fieldset} id="location" options=${['Option 1']}><h1>Where do you live?</h1><//>
         `,
       ),
     )
@@ -40,16 +38,12 @@ describe('<Fieldset>', () => {
   })
 
   test('renders rows of radios', () => {
-    const rows = [
-      { key: 'Zurich', value: 'zurich' },
-      { key: 'St. Petersberg', value: 'petersburg' },
-      { key: 'Stockholm', value: 'stockholm' },
-    ]
+    const options = ['Zurich', 'St. Petersburg', 'Stockholm']
 
     const $ = cheerio.load(
       render(
         html`
-          <${Fieldset} id="location" rows=${rows}><h1>Where do you live?</h1><//>
+          <${Fieldset} id="location" options=${options}><h1>Where do you live?</h1><//>
         `,
       ),
     )
@@ -58,27 +52,25 @@ describe('<Fieldset>', () => {
 
     expect($('fieldset input').length).toBe(3)
 
-    rows.map((row, index) => {
+    options.map((label, index) => {
       let input = $('fieldset input').eq(index)
 
       expect(input.attr('name')).toEqual('location')
       expect(input.attr('id')).toEqual(`location-${index}`)
-      expect(input.attr('value')).toEqual(row.value)
-      expect(input.next('label').text()).toEqual(row.key)
+      expect(input.attr('value')).toEqual(label)
+      expect(input.next('label').text()).toEqual(label)
     })
   })
 
   test('renders with correctly selected radio value', () => {
-    const rows = [
-      { key: 'Zurich', value: 'zurich' },
-      { key: 'St. Petersberg', value: 'petersburg' },
-      { key: 'Stockholm', value: 'stockholm' },
-    ]
+    const options = ['Zurich', 'St. Petersburg', 'Stockholm']
 
     const $ = cheerio.load(
       render(
         html`
-          <${Fieldset} id="location" rows=${rows} value="petersburg"><h1>Where do you live?</h1><//>
+          <${Fieldset} id="location" options=${options} value="St. Petersburg"
+            ><h1>Where do you live?</h1><//
+          >
         `,
       ),
     )
@@ -87,7 +79,7 @@ describe('<Fieldset>', () => {
 
     expect($('fieldset input').length).toBe(3)
     const secondInput = $('fieldset input').eq(1)
-    expect(secondInput.next('label').text()).toEqual('St. Petersberg')
+    expect(secondInput.next('label').text()).toEqual('St. Petersburg')
     expect(secondInput.attr('checked')).toBeDefined()
   })
 })

--- a/src/components/forms/__tests__/Fieldset.test.js
+++ b/src/components/forms/__tests__/Fieldset.test.js
@@ -1,0 +1,20 @@
+const render = require('preact-render-to-string')
+const cheerio = require('cheerio')
+const { html } = require('../../../utils.js')
+
+const Fieldset = require('../Fieldset.js')
+
+describe('<Fieldset>', () => {
+  test('renders with children', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Fieldset}><h1>Where do you live?</h1><//>
+        `,
+      ),
+    )
+    expect($('fieldset').length).toBe(1)
+    expect($('fieldset legend h1').length).toBe(1)
+    expect($('fieldset legend h1').text()).toEqual('Where do you live?')
+  })
+})

--- a/src/components/forms/__tests__/Fieldset.test.js
+++ b/src/components/forms/__tests__/Fieldset.test.js
@@ -67,4 +67,27 @@ describe('<Fieldset>', () => {
       expect(input.next('label').text()).toEqual(row.key)
     })
   })
+
+  test('renders with correctly selected radio value', () => {
+    const rows = [
+      { key: 'Zurich', value: 'zurich' },
+      { key: 'St. Petersberg', value: 'petersburg' },
+      { key: 'Stockholm', value: 'stockholm' },
+    ]
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Fieldset} id="location" rows=${rows} value="petersburg"><h1>Where do you live?</h1><//>
+        `,
+      ),
+    )
+    expect($('fieldset').length).toBe(1)
+    expect($('fieldset legend h1').length).toBe(1)
+
+    expect($('fieldset input').length).toBe(3)
+    const secondInput = $('fieldset input').eq(1)
+    expect(secondInput.next('label').text()).toEqual('St. Petersberg')
+    expect(secondInput.attr('checked')).toBeDefined()
+  })
 })

--- a/src/components/forms/__tests__/Fieldset.test.js
+++ b/src/components/forms/__tests__/Fieldset.test.js
@@ -22,7 +22,9 @@ describe('<Fieldset>', () => {
     const $ = cheerio.load(
       render(
         html`
-          <${Fieldset} id="location"><h1>Where do you live?</h1><//>
+          <${Fieldset} id="location" rows=${[{ key: 'r1', value: 'r1' }]}
+            ><h1>Where do you live?</h1><//
+          >
         `,
       ),
     )
@@ -34,6 +36,35 @@ describe('<Fieldset>', () => {
       $('fieldset input')
         .first()
         .attr('id'),
-    ).toEqual('location-1')
+    ).toEqual('location-0')
+  })
+
+  test('renders rows of radios', () => {
+    const rows = [
+      { key: 'Zurich', value: 'zurich' },
+      { key: 'St. Petersberg', value: 'petersburg' },
+      { key: 'Stockholm', value: 'stockholm' },
+    ]
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Fieldset} id="location" rows=${rows}><h1>Where do you live?</h1><//>
+        `,
+      ),
+    )
+    expect($('fieldset').length).toBe(1)
+    expect($('fieldset legend h1').length).toBe(1)
+
+    expect($('fieldset input').length).toBe(3)
+
+    rows.map((row, index) => {
+      let input = $('fieldset input').eq(index)
+
+      expect(input.attr('name')).toEqual('location')
+      expect(input.attr('id')).toEqual(`location-${index}`)
+      expect(input.attr('value')).toEqual(row.value)
+      expect(input.next('label').text()).toEqual(row.key)
+    })
   })
 })

--- a/src/components/forms/__tests__/Input.test.js
+++ b/src/components/forms/__tests__/Input.test.js
@@ -4,7 +4,7 @@ const { html } = require('../../../utils.js')
 
 const Input = require('../Input.js')
 
-describe('<Input>', () => {
+describe('TextInput <Input>', () => {
   test('renders as expected', () => {
     const $ = cheerio.load(
       render(
@@ -103,5 +103,91 @@ describe('<Input>', () => {
         .prev()
         .attr('id'),
     ).toEqual('city-error')
+  })
+})
+
+describe('Textarea <Input>', () => {
+  test('renders as expected', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Input} type="textarea" id="address">Mailing address<//>
+        `,
+      ),
+    )
+    expect($('textarea').length).toBe(1)
+    expect($('textarea').attr('id')).toEqual('address')
+    expect($('textarea').attr('name')).toEqual('address')
+    expect($('textarea').attr('type')).toBeUndefined()
+    expect($('textarea').attr('value')).toBeUndefined()
+    expect($('textarea').text()).toEqual('')
+
+    expect($('label').length).toBe(1)
+    expect($('label').attr('for')).toEqual('address')
+    expect($('label').text()).toEqual('Mailing address')
+  })
+
+  test('renders with passed-in attributes', () => {
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Input}
+            type="textarea"
+            id="thesis"
+            name="thesis-1"
+            july="days"
+            value="In our attitude"
+            >Thesis 1<//
+          >
+        `,
+      ),
+    )
+    expect($('textarea').length).toBe(1)
+    expect($('textarea').attr('id')).toEqual('thesis')
+    expect($('textarea').attr('name')).toEqual('thesis-1')
+    expect($('textarea').attr('type')).toBeUndefined()
+    expect($('textarea').attr('value')).toBeUndefined()
+    expect($('textarea').attr('july')).toEqual('days')
+    expect($('textarea').text()).toEqual('In our attitude')
+
+    expect($('label').length).toBe(1)
+    expect($('label').attr('for')).toEqual('thesis')
+    expect($('label').text()).toBe('Thesis 1')
+  })
+
+  test('renders with a validation error', () => {
+    const error = { param: 'platform', msg: 'Not a rousing message' }
+
+    const $ = cheerio.load(
+      render(
+        html`
+          <${Input} type="textarea" id="platform" error=${error}
+            >Our platform<//
+          >
+        `,
+      ),
+    )
+    expect($('textarea').length).toBe(1)
+    expect($('textarea').attr('id')).toEqual('platform')
+
+    expect($('label').length).toBe(1)
+    expect($('label').text()).toBe('Our platform')
+
+    expect($('span#platform-error').length).toBe(1)
+    expect($('span#platform-error').text()).toBe('Error: Not a rousing message')
+    expect($('textarea').attr('aria-describedby')).toEqual('platform-error')
+
+    // expect validation message is after the label
+    expect(
+      $('label')
+        .next()
+        .attr('id'),
+    ).toEqual('platform-error')
+    // expect validation message is before the textarea
+    expect(
+      $('textarea')
+        .prev()
+        .attr('id'),
+    ).toEqual('platform-error')
   })
 })

--- a/src/pages/AboutYou.js
+++ b/src/pages/AboutYou.js
@@ -6,7 +6,10 @@ const SummaryTable = require('../components/SummaryTable.js')
 const ButtonLink = require('../components/ButtonLink.js')
 
 const aboutYouRows = ({ name, address }) => {
-  return [{ key: 'Name', value: name }, { key: 'Mailing address', value: address }]
+  return [
+    { key: 'Name', value: name, id: 'name' },
+    { key: 'Mailing address', value: address, id: 'address' },
+  ]
 }
 
 const AboutYou = ({ data = {} }) =>
@@ -20,7 +23,7 @@ const AboutYou = ({ data = {} }) =>
           out-of-date information and then continue to the next section.
         </p>
 
-        <${SummaryTable} rows=${aboutYouRows(data)} ifEditable=${true} //>
+        <${SummaryTable} rows=${aboutYouRows(data)} />
         <p>
           There are <strong>2 sections</strong> remaining, which should take ${' '}<strong
             >5 minutes</strong

--- a/src/pages/Introduction.js
+++ b/src/pages/Introduction.js
@@ -39,9 +39,9 @@ const Introduction = ({ data = {} }) =>
         </p>
         <p>If any of this information is wrong, you’ll have a chance to update it.</p>
 
-        <${SummaryTable} title="About you" rows=${aboutYouRows(data)} ifEditable=${false} //>
-        <${SummaryTable} title="Your family" rows=${yourFamilyRows(data)} ifEditable=${false} //>
-        <${SummaryTable} title="Your income" rows=${yourIncomeRows(data)} ifEditable=${false} //>
+        <${SummaryTable} title="About you" rows=${aboutYouRows(data)} />
+        <${SummaryTable} title="Your family" rows=${yourFamilyRows(data)} />
+        <${SummaryTable} title="Your income" rows=${yourIncomeRows(data)} />
 
         <p>
           On the following pages, you can review each section and correct any outdated information.

--- a/src/pages/T4.js
+++ b/src/pages/T4.js
@@ -35,7 +35,7 @@ const T4 = ({ data = {} }) =>
           <img class=${imgCSS} src="/t4.png" title="Sample T4 form" />
         </div>
 
-        <${SummaryTable} title="Income Data" rows=${t4Data(data.income)} ifEditable=${false} //>
+        <${SummaryTable} title="Income Data" rows=${t4Data(data.income)} />
 
         <p>
           This is the <strong>last section</strong>. You will have the opportunity to review all

--- a/src/pages/YourFamily.js
+++ b/src/pages/YourFamily.js
@@ -23,7 +23,7 @@ const YourFamily = ({ data = {} }) =>
           you. Please update any out-of-date information and then continue to the next section.
         </p>
 
-        <${SummaryTable} rows=${yourFamilyRows(data)} ifEditable=${true} //>
+        <${SummaryTable} rows=${yourFamilyRows(data)} />
         <p>
           There is <strong>1 section</strong> remaining, which should take ${' '}<strong
             >1 minute</strong

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -12,7 +12,7 @@ const document = ({ title, locale, content }) => {
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta name="description" content="[WIP] A benefit signup prototype by the Canadian Digital Service">
-        <link rel="shortcut icon" href="favicon.png" type="image/x-icon" sizes="32x32"  />
+        <link rel="shortcut icon" href="/favicon.png" type="image/x-icon" sizes="32x32"  />
         <title>${title}</title>
         <style>
           * {


### PR DESCRIPTION
Pull Request #36 has become a 600-line change request, but much of that is adding new form elements or fixing small bugs — ie, it's the setup work needed for the edit pages to exist. 

In order to simplify that PR, I've added this one which refactors the commit history so that all the basic changes go in first (without affecting the existing functionality). There are no visual or functional changes in this pull request.

Specifically, this pull request: 

- adds a `<textarea>` component (used for longer text inputs)
- refactors the `SummaryTable` component so that it doesn't need `ifEditable` anymore
- Adds a `<fieldset>` component (used to group together related form elements)
-  Updates the validation messages to be `display: block` so that small inputs don't end up on the same line as error messages
- Updates the functional tests to pass again now that the `/dashboard` page was changed to `/introduction`
- Fixes the favicon link in the document `<head>`