### PR TITLE
Update packages + fix spacing for header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2320,9 +2320,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "22.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz",
-      "integrity": "sha512-gcLfn6P2PrFAVx3AobaOzlIEevpAEf9chTpFZz7bYfc7pz8XRv7vuKTIE4hxPKZSha6XWKKplDQ0x9Pq8xX2mg==",
+      "version": "22.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.5.1.tgz",
+      "integrity": "sha512-c3WjZR/HBoi4GedJRwo2OGHa8Pzo1EbSVwQ2HFzJ+4t2OoYM7Alx646EH/aaxZ+9eGcPiq0FT0UGkRuFFx2FHg==",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cypress": "^3.2.0",
     "eslint": "^5.16.0",
     "eslint-plugin-cypress": "^2.2.1",
-    "eslint-plugin-jest": "^22.4.1",
+    "eslint-plugin-jest": "^22.5.1",
     "jest": "^24.7.1",
     "nodemon": "^1.18.11",
     "start-server-and-test": "^1.9.0",

--- a/src/styles.js
+++ b/src/styles.js
@@ -81,6 +81,12 @@ const loggedInStyles = css`
   a.buttonLink {
     width: 200px;
   }
+
+  @media (${theme.mq.sm}) {
+    h1 {
+      margin-right: ${theme.space.xxl};
+    }
+  }
 `
 
 module.exports = {


### PR DESCRIPTION
### Upgrade packages

Just a patch update to a testing library.

### Add right margin to logged-in page headings 

On small screens with long titles, the header overlaps the the "log out" link. Adding a margin to the title that's larger than the "log out" link solves this.

## screenshots

|  before  | after   |
|---|---|
| <img width="512" alt="Screen Shot 2019-04-28 at 8 08 09 PM" src="https://user-images.githubusercontent.com/2454380/56871960-a4893100-69f1-11e9-8ca8-e9547771390c.png" /> | <img width="512" alt="Screen Shot 2019-04-28 at 8 08 11 PM" src="https://user-images.githubusercontent.com/2454380/56871959-a226d700-69f1-11e9-9976-887739084a61.png" /> | 



