### PR TITLE
Remove SimpleSummaryRow

### DIFF
--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -66,7 +66,7 @@ const summaryRow = css`
     }
   }
 `
-const SummaryRow = ({ row: { key, value, id = false } = {} }) => {
+const SummaryRow = ({ key, value, id = false }) => {
   return html`
     <div class=${summaryRow}>
       <dt class="key">
@@ -88,18 +88,9 @@ const SummaryRow = ({ row: { key, value, id = false } = {} }) => {
   `
 }
 
-const SimpleSummaryRow = ({key, value}) => {
-  return html`
-    <div class=${summaryRow}>
-      <dt class="key">${key}</dt>
-      <dd class="value">${value}</dd>
-    </div>
-  `
-}
-
 const renderSummaryRow = (row, props) =>
   html`
-    <${SummaryRow} row=${row} ...${props} //>
+    <${SummaryRow} key=${row.key} value=${row.value} id=${row.id} ...${props} //>
   `
 
 const summaryTable = css`
@@ -143,4 +134,4 @@ const SummaryTable = ({ rows, title = false, ...props }) =>
     </div>
   `
 
-module.exports = { SummaryTable, summaryRow, SimpleSummaryRow }
+module.exports = { SummaryTable, SummaryRow }

--- a/src/components/__tests__/SummaryTable.test.js
+++ b/src/components/__tests__/SummaryTable.test.js
@@ -2,7 +2,7 @@ const render = require('preact-render-to-string')
 const cheerio = require('cheerio')
 const { html } = require('../../utils.js')
 
-const { SummaryTable } = require('../SummaryTable.js')
+const { SummaryTable, SummaryRow } = require('../SummaryTable.js')
 
 const getCell = ({ cheerio, rowNum = 0, find }) =>
   cheerio('dl div')
@@ -19,9 +19,10 @@ const renderTable = props => {
   )
 }
 
-describe('<SummaryTable>', () => {
-  const rows = [{ key: 'Full name', value: 'Fred Smith' }]
+const rows = [{ key: 'Full name', value: 'Fred Smith' }]
+const rowsWithId = [{ key: 'Full name', value: 'Fred Smith', id: 'name' }]
 
+describe('<SummaryTable>', () => {
   test('renders <dl> element and 1 row', () => {
     const $ = renderTable({ rows })
 
@@ -47,8 +48,6 @@ describe('<SummaryTable>', () => {
 
   describe('it renders cells with 1 row', () => {
     test('INCLUDING edit links', () => {
-      let rowsWithId = [{ key: 'Full name', value: 'Fred Smith', id: 'name' }]
-
       const $ = renderTable({ rows: rowsWithId })
 
       // first row
@@ -74,12 +73,9 @@ describe('<SummaryTable>', () => {
 
   describe('it renders cells with 2 rows', () => {
     test('INCLUDING edit links', () => {
-      let rowsWithId = [
-        { key: 'Full name', value: 'Fred Smith', id: 'name' },
-        { key: 'Date of birth', value: '18-06-1971', id: 'dob' },
-      ]
+      let rowsYesId = rowsWithId.concat([{ key: 'Date of birth', value: '18-06-1971', id: 'dob' }])
 
-      const $ = renderTable({ rows: rowsWithId })
+      const $ = renderTable({ rows: rowsYesId })
 
       // first row
       expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
@@ -108,5 +104,33 @@ describe('<SummaryTable>', () => {
       expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual('18-06-1971')
       expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).length).toBe(0)
     })
+  })
+})
+
+const renderRow = props => {
+  return cheerio.load(
+    render(
+      html`
+        <${SummaryRow} ...${props} />
+      `,
+    ),
+  )
+}
+
+describe('<SummaryRow>', () => {
+  test('renders a row WITHOUT edit links', () => {
+    const $ = renderRow(rows[0])
+
+    expect($('dt.key').text()).toEqual('Full name')
+    expect($('dd.value').text()).toEqual('Fred Smith')
+    expect($('dd.action').length).toBe(0)
+  })
+
+  test('renders a row WITH edit links', () => {
+    const $ = renderRow(rowsWithId[0])
+
+    expect($('dt.key').text()).toEqual('Full name')
+    expect($('dd.value').text()).toEqual('Fred Smith')
+    expect($('dd.action').text()).toBe('Change full name')
   })
 })

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -88,15 +88,19 @@ const Checklist = ({ user = {}, locale }) =>
 
         <h2>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
-        <${SummaryRow} value=${user.return.line150} key="Total income:" />
-        <${SummaryRow} value=${user.return.line260} key="Taxable income:" />
-        <${SummaryRow} value=${user.return.line482} key="Total tax credits:" />
+        <dl>
+          <${SummaryRow} value=${user.return.line150} key="Total income:" />
+          <${SummaryRow} value=${user.return.line260} key="Taxable income:" />
+          <${SummaryRow} value=${user.return.line482} key="Total tax credits:" />
+        </dl>
 
         <${Accordion} checked=${true}>
           <${SummaryTable} rows=${totalTaxRows(user.return)} />
         <//>
 
-        <${SummaryRow} value=${user.return.line484} key="Refund" />
+        <dl>
+          <${SummaryRow} value=${user.return.line484} key="Refund" />
+        </dl>
 
         <${Accordion} checked=${true}>
           <${SummaryTable} rows=${refundRows(user.return)} />

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -4,7 +4,7 @@ const { html } = require('../utils.js')
 const Layout = require('../components/Layout.js')
 const Accordion = require('../components/Accordion.js')
 const LogoutLink = require('../components/LogoutLink.js')
-const { SummaryTable, SimpleSummaryRow } = require('../components/SummaryTable.js')
+const { SummaryTable, SummaryRow } = require('../components/SummaryTable.js')
 const ButtonLink = require('../components/ButtonLink.js')
 const polyglot = require('../i18n.js')
 
@@ -88,15 +88,15 @@ const Checklist = ({ user = {}, locale }) =>
 
         <h2>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
-        <${SimpleSummaryRow} value=${user.return.line150} key="Total income:" />
-        <${SimpleSummaryRow} value=${user.return.line260} key="Taxable income:" />
-        <${SimpleSummaryRow} value=${user.return.line482} key="Total tax credits:" />
+        <${SummaryRow} value=${user.return.line150} key="Total income:" />
+        <${SummaryRow} value=${user.return.line260} key="Taxable income:" />
+        <${SummaryRow} value=${user.return.line482} key="Total tax credits:" />
 
         <${Accordion} checked=${true}>
           <${SummaryTable} rows=${totalTaxRows(user.return)} />
         <//>
 
-        <${SimpleSummaryRow} value=${user.return.line484} key="Refund" />
+        <${SummaryRow} value=${user.return.line484} key="Refund" />
 
         <${Accordion} checked=${true}>
           <${SummaryTable} rows=${refundRows(user.return)} />


### PR DESCRIPTION
SimpleSummaryRow was effectively duplicating SummaryRow.
A small refactor means we can remove SimpleSummaryRow forever.

Also added some markup to the checklist page for semantic reasons, and added a couple tests for SummaryRow.