### PR TITLE
Checklist styling

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -98,7 +98,7 @@ action "Run lighthouse scan on landing page" {
   uses = "docker://cdssnc/lighthouse-score-github-action"
   secrets = ["LIGHTHOUSE_SECRET", "LIGHTHOUSE_URL"]
   env = {
-    LIGHTHOUSE_SCORES = "[99, 99, 90, 99, 50]"
+    LIGHTHOUSE_SCORES = "[97, 99, 90, 99, 50]"
   }
 }
 

--- a/cypress/fixtures/user.json
+++ b/cypress/fixtures/user.json
@@ -1,5 +1,6 @@
 {
-  "name": "Avril Douglas Campbell",
+  "firstName": "Avril",
+  "lastName": "Campbell",
   "address": "850 Argyle Street\nPort Alberni\nBritish Columbia\nV9Y 1V8",
   "maritalStatus": "Married",
   "children": "0",

--- a/cypress/integration/full_run.spec.js
+++ b/cypress/integration/full_run.spec.js
@@ -1,4 +1,3 @@
-const { getFirstName } = require('../../src/api.js')
 const { checkTableRows, logIn } = require('../utils.js')
 
 describe('Full run through', function() {
@@ -19,9 +18,9 @@ describe('Full run through', function() {
 
       // INTRODUCTION PAGE
       cy.url().should('contain', '/introduction')
-      cy.get('h1').should('contain', `Hi, ${getFirstName(user.name)}`)
+      cy.get('h1').should('contain', `Hi, ${user.firstName}`)
 
-      /* 
+      /*
 
       cy.get('h2')
         .first()
@@ -41,7 +40,7 @@ describe('Full run through', function() {
       cy.get('h1').should('contain', 'About you')
 
       checkTableRows(cy, [
-        { key: 'Name', value: user.name },
+        { key: 'Name', value: user.firstName + ' ' + user.lastName },
         { key: 'Mailing address', value: user.address },
         { key: 'Marital status', value: user.maritalStatus },
         { key: 'Number of children', value: user.children },
@@ -56,7 +55,7 @@ describe('Full run through', function() {
       cy.get('h1').should('contain', 'Success!')
       cy.get('h1')
         .next('p')
-        .should('contain', `Good job, ${getFirstName(user.name)}!`)
+        .should('contain', `Good job, ${user.firstName}!`)
     })
   })
 })

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -1,6 +1,6 @@
 const checkTableRows = (cy, rows) => {
   rows.map((row, index) => {
-    cy.get('dt.key')
+    cy.get('dt.keyBold')
       .eq(index)
       .should('contain', row.key)
       .next('dd')

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -1,6 +1,6 @@
 const checkTableRows = (cy, rows) => {
   rows.map((row, index) => {
-    cy.get('dt.keyBold')
+    cy.get('dt.key')
       .eq(index)
       .should('contain', row.key)
       .next('dd')

--- a/cypress/utils.js
+++ b/cypress/utils.js
@@ -38,8 +38,8 @@ const logIn = (cy, user) => {
 
   cy.get('form label').should('have.attr', 'for', 'login')
   cy.get('form input#login')
-    .type(user.name)
-    .should('have.value', user.name)
+    .type(user.firstName)
+    .should('have.value', user.firstName)
   cy.get('form button')
     .should('contain', 'Log in')
     .click()

--- a/src/api.js
+++ b/src/api.js
@@ -2,7 +2,8 @@ var API = (function() {
   const _john = {
     _matches: ['john', 'j'],
     personal: {
-      name: 'John Caldwell Abbott',
+      firstName: 'John',
+      lastName: 'Abbott',
       address: '21275 Lakeshore Dr\nSainte-Anne-de-Bellevue\nQuébec\nH9X 3L9',
       maritalStatus: 'Widowed',
       children: '8',
@@ -52,7 +53,8 @@ var API = (function() {
   const _arthur = {
     _matches: ['arthur', 'art', 'a'],
     personal: {
-      name: 'Arthur Meighen',
+      firstName: 'Arthur',
+      lastName: 'Meighen',
       address: '23 St Clair Ave East\nToronto\nOntario\nM4T 1M4',
       maritalStatus: 'Married',
       children: '3',
@@ -102,7 +104,8 @@ var API = (function() {
   const _louis = {
     _matches: ['louis', 'lou', 'l'],
     personal: {
-      name: 'Louis Stephen St. Laurent',
+      firstName: 'Louis',
+      lastName: 'St. Laurent',
       address: '459-455 Boulevard de la Carrière\nGatineau\nQuébec\nJ8Y 6V7',
       maritalStatus: 'Widowed',
       children: '5',
@@ -162,7 +165,8 @@ var API = (function() {
   const _kim = {
     _matches: ['avril', 'kim', 'k'],
     personal: {
-      name: 'Avril Douglas Campbell',
+      firstName: 'Avril',
+      lastName: 'Campbell',
       address: '850 Argyle Street\nPort Alberni\nBritish Columbia\nV9Y 1V8',
       maritalStatus: 'Married',
       children: '0',
@@ -212,7 +216,9 @@ var API = (function() {
 
   const _users = [_john, _arthur, _louis, _kim]
 
-  const getFirstName = (name = '') => name.trim().split(' ')[0]
+  const getFirstName = (firstName = '') => firstName.trim().split(' ')[0]
+
+  const getFullName = user => user.personal.firstName + ' ' + user.personal.lastName
 
   const getUser = name => {
     let found = null

--- a/src/api.js
+++ b/src/api.js
@@ -218,8 +218,6 @@ var API = (function() {
 
   const getFirstName = (firstName = '') => firstName.trim().split(' ')[0]
 
-  const getFullName = user => user.personal.firstName + ' ' + user.personal.lastName
-
   const getUser = name => {
     let found = null
 

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -8,7 +8,7 @@ const Accordion = ({ children, header, checked }) =>
         <li>
         ${checked ? html`<input type="checkbox" checked/>` : html`<input type="checkbox" unchecked/>`}
           <i></i>
-          ${header ? html`<h2>${header}</h2>` : html`<p tabindex="0" id="show-hide">Show/Hide details</p>`} 
+          ${header ? html`<h2>${header}</h2>` : html`<p id="show-hide">Show/Hide details</p>`} 
 
           <div name="accordion">
             ${children}

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -8,7 +8,7 @@ const Accordion = ({ children, header, checked }) =>
         <li>
         ${checked ? html`<input type="checkbox" checked/>` : html`<input type="checkbox" unchecked/>`}
           <i></i>
-          ${header ? html`<h2>${header}</h2>` : html`<p tabindex="0" id="show-hide"></p>`} 
+          ${header ? html`<h2>${header}</h2>` : html`<p tabindex="0" id="show-hide">Show/Hide details</p>`} 
 
           <div name="accordion">
             ${children}

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -8,7 +8,7 @@ const Accordion = ({ children, header, checked }) =>
         <li>
         ${checked ? html`<input type="checkbox" checked/>` : html`<input type="checkbox" unchecked/>`}
           <i></i>
-          ${header ? html`<h2>${header}</h2>` : html`<p>Show Details</p>`} 
+          ${header ? html`<h2>${header}</h2>` : html`<p id="show-hide"></p>`} 
 
           <div name="accordion">
             ${children}

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -8,7 +8,7 @@ const Accordion = ({ children, header, checked }) =>
         <li>
         ${checked ? html`<input type="checkbox" checked/>` : html`<input type="checkbox" unchecked/>`}
           <i></i>
-          ${header ? html`<h2>${header}</h2>` : html`<p id="show-hide">Show/Hide details</p>`} 
+          ${header ? html`<h2>${header}</h2>` : html`<p class="show-hide">Show/Hide details</p>`} 
 
           <div name="accordion">
             ${children}

--- a/src/components/Accordion.js
+++ b/src/components/Accordion.js
@@ -8,7 +8,7 @@ const Accordion = ({ children, header, checked }) =>
         <li>
         ${checked ? html`<input type="checkbox" checked/>` : html`<input type="checkbox" unchecked/>`}
           <i></i>
-          ${header ? html`<h2>${header}</h2>` : html`<p id="show-hide"></p>`} 
+          ${header ? html`<h2>${header}</h2>` : html`<p tabindex="0" id="show-hide"></p>`} 
 
           <div name="accordion">
             ${children}

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -1,6 +1,6 @@
 const { css } = require('emotion')
 const { theme, visuallyHidden } = require('../styles.js')
-const { html } = require('../utils.js')
+const { html, currencyFormatter } = require('../utils.js')
 
 const summaryRow = css`
   @media (${theme.mq.sm}) {
@@ -49,22 +49,22 @@ const summaryRow = css`
     }
   }
 `
-const SummaryRow = ({ key, value, id = false }) => {
+const SummaryRow = ({ key, value, id = false, currency }) => {
   return html`
     <div class=${summaryRow}>
       <dt class="key">
         ${key}:
       </dt>
       <dd class="value">
-        ${value}
+      ${currency === true ? currencyFormatter.format(value) : value }
       </dd>
     </div>
   `
 }
 
-const renderSummaryRow = (row, props) =>
+const renderSummaryRow = (currency, row, props) =>
   html`
-    <${SummaryRow} key=${row.key} value=${row.value} id=${row.id} ...${props} //>
+    <${SummaryRow} currency=${currency} key=${row.key} value=${row.value} id=${row.id} ...${props} //>
   `
 
 const summaryTable = css`
@@ -90,7 +90,7 @@ const summaryTable = css`
   }
 `
 
-const SummaryTable = ({ rows, title = false, ...props }) =>
+const SummaryTable = ({ currency, rows, title = false, ...props }) =>
   html`
     <div class=${summaryTable}>
       ${title &&
@@ -98,7 +98,7 @@ const SummaryTable = ({ rows, title = false, ...props }) =>
           <h2>${title}</h2>
         `}
       <dl title=${title}>
-        ${rows.map(row => renderSummaryRow(row, props))}
+        ${rows.map(row => renderSummaryRow(currency, row, props))}
       </dl>
     </div>
   `

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -1,5 +1,5 @@
 const { css } = require('emotion')
-const { theme, visuallyHidden } = require('../styles.js')
+const { theme } = require('../styles.js')
 const { html, currencyFormatter } = require('../utils.js')
 
 const summaryRow = css`
@@ -51,7 +51,7 @@ const summaryRow = css`
 `
 const SummaryRow = ({ key, value, id = false, currency }) => {
   return html`
-    <div class=${summaryRow}>
+    <div id=${id} class=${summaryRow}>
       <dt class="key">
         ${key}:
       </dt>

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -18,6 +18,10 @@ const summaryRow = css`
 
   .key {
     margin-bottom: ${theme.space.xxs};
+  }
+
+  .keyBold {
+    margin-bottom: ${theme.space.xxs};
     font-weight: 700;
   }
 
@@ -27,13 +31,15 @@ const summaryRow = css`
 
   @media (${theme.mq.lg}) {
     .key,
+    .keyBold,
     .value {
       display: table-cell;
       padding-right: ${theme.space.lg};
       padding-bottom: ${theme.space.sm};
     }
 
-    .key {
+    .key,
+    .keyBold {
       width: 35%;
     }
 
@@ -48,22 +54,23 @@ const summaryRow = css`
     }
   }
 `
-const SummaryRow = ({ key, value, id = false, currency }) => {
+const SummaryRow = ({ keyBold, key, value, id = false, currency }) => {
   return html`
     <div id=${id} class=${summaryRow}>
-      <dt class="key">
+      <dt class=${keyBold === true ? 'keyBold' : 'key'}>
         ${key}:
       </dt>
       <dd class="value">
-      ${currency === true ? currencyFormatter.format(value) : value }
+        ${currency === true ? currencyFormatter.format(value) : value}
       </dd>
     </div>
   `
 }
 
-const renderSummaryRow = (currency, row, props) =>
+const renderSummaryRow = (keyBold, currency, row, props) =>
   html`
-    <${SummaryRow} currency=${currency} key=${row.key} value=${row.value} id=${row.id} ...${props} //>
+    <${SummaryRow} keyBold=${keyBold} currency=${currency} key=${row.key} value=${row.value}
+    id=${row.id} ...${props} //>
   `
 
 const summaryTable = css`
@@ -89,7 +96,7 @@ const summaryTable = css`
   }
 `
 
-const SummaryTable = ({ currency, rows, title = false, ...props }) =>
+const SummaryTable = ({ keyBold, currency, rows, title = false, ...props }) =>
   html`
     <div class=${summaryTable}>
       ${title &&
@@ -97,7 +104,7 @@ const SummaryTable = ({ currency, rows, title = false, ...props }) =>
           <h2>${title}</h2>
         `}
       <dl title=${title}>
-        ${rows.map(row => renderSummaryRow(currency, row, props))}
+        ${rows.map(row => renderSummaryRow(keyBold, currency, row, props))}
       </dl>
     </div>
   `

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -1,6 +1,6 @@
 const { css } = require('emotion')
 const { theme } = require('../styles.js')
-const { html, currencyFormatter } = require('../utils.js')
+const { html } = require('../utils.js')
 
 const summaryRow = css`
   @media (${theme.mq.sm}) {
@@ -20,7 +20,7 @@ const summaryRow = css`
     margin-bottom: ${theme.space.xxs};
   }
 
-  .keyBold {
+  .key--bold {
     margin-bottom: ${theme.space.xxs};
     font-weight: 700;
   }
@@ -31,15 +31,13 @@ const summaryRow = css`
 
   @media (${theme.mq.lg}) {
     .key,
-    .keyBold,
     .value {
       display: table-cell;
       padding-right: ${theme.space.lg};
       padding-bottom: ${theme.space.sm};
     }
 
-    .key,
-    .keyBold {
+    .key {
       width: 35%;
     }
 
@@ -54,22 +52,22 @@ const summaryRow = css`
     }
   }
 `
-const SummaryRow = ({ keyBold, key, value, id = false, currency }) => {
+const SummaryRow = ({ keyBold = true, key, value, id = false }) => {
   return html`
     <div id=${id} class=${summaryRow}>
-      <dt class=${keyBold === true ? 'keyBold' : 'key'}>
+      <dt class=${keyBold === true ? 'key key--bold' : 'key'}>
         ${key}:
       </dt>
       <dd class="value">
-        ${currency === true ? currencyFormatter.format(value) : value}
+        ${value}
       </dd>
     </div>
   `
 }
 
-const renderSummaryRow = (keyBold, currency, row, props) =>
+const renderSummaryRow = (keyBold, row, props) =>
   html`
-    <${SummaryRow} keyBold=${keyBold} currency=${currency} key=${row.key} value=${row.value}
+    <${SummaryRow} keyBold=${keyBold} key=${row.key} value=${row.value}
     id=${row.id} ...${props} //>
   `
 
@@ -96,7 +94,7 @@ const summaryTable = css`
   }
 `
 
-const SummaryTable = ({ keyBold, currency, rows, title = false, ...props }) =>
+const SummaryTable = ({ keyBold, rows, title = false, ...props }) =>
   html`
     <div class=${summaryTable}>
       ${title &&
@@ -104,7 +102,7 @@ const SummaryTable = ({ keyBold, currency, rows, title = false, ...props }) =>
           <h2>${title}</h2>
         `}
       <dl title=${title}>
-        ${rows.map(row => renderSummaryRow(keyBold, currency, row, props))}
+        ${rows.map(row => renderSummaryRow(keyBold, row, props))}
       </dl>
     </div>
   `

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -3,13 +3,11 @@ const { theme, visuallyHidden } = require('../styles.js')
 const { html } = require('../utils.js')
 
 const summaryRow = css`
-  @media (${theme.mq.lg}) {
-    display: table-row;
-  }
-
   @media (${theme.mq.sm}) {
     margin-bottom: ${theme.space.sm};
   }
+
+  display: table-row;
 
   .key,
   .value {
@@ -20,21 +18,16 @@ const summaryRow = css`
 
   .key {
     margin-bottom: ${theme.space.xxs};
+    font-weight: 700;
   }
 
   .value {
     white-space: pre-wrap;
   }
 
-  .action {
-    margin: 0;
-    margin-bottom: ${theme.space.sm};
-  }
-
   @media (${theme.mq.lg}) {
     .key,
-    .value,
-    .action {
+    .value {
       display: table-cell;
       padding-right: ${theme.space.lg};
       padding-top: ${theme.space.xs};
@@ -42,25 +35,15 @@ const summaryRow = css`
     }
 
     .key {
-      width: 30%;
+      width: 35%;
     }
 
     .value {
-      width: 50%;
-    }
-
-    .action {
-      width: 20%;
-      padding-right: 0;
-      text-align: right;
+      width: 45%;
     }
   }
 
   @media (${theme.mq.sm}) {
-    .key {
-      font-weight: 700;
-    }
-
     .value {
       margin-bottom: ${theme.space.sm};
     }
@@ -70,20 +53,11 @@ const SummaryRow = ({ key, value, id = false }) => {
   return html`
     <div class=${summaryRow}>
       <dt class="key">
-        ${key}
+        ${key}:
       </dt>
       <dd class="value">
         ${value}
       </dd>
-      ${id &&
-        html`
-          <dd class="action">
-            <a href=${`/edit/${id}`}>
-              Change
-              <span class="${visuallyHidden}">${` ${key && key.toLowerCase()}`}</span>
-            </a>
-          </dd>
-        `}
     </div>
   `
 }
@@ -94,14 +68,9 @@ const renderSummaryRow = (row, props) =>
   `
 
 const summaryTable = css`
-  dl {
-    margin: 0;
-    margin-bottom: ${theme.space.xl};
-  }
-
   h2 {
     font-size: 1.3em;
-    margin: ${theme.space.lg} 0 ${theme.space.xs} 0;
+    margin: 0;
     padding-bottom: ${theme.space.xxs};
     border-bottom: 1px solid black;
   }

--- a/src/components/SummaryTable.js
+++ b/src/components/SummaryTable.js
@@ -30,8 +30,7 @@ const summaryRow = css`
     .value {
       display: table-cell;
       padding-right: ${theme.space.lg};
-      padding-top: ${theme.space.xs};
-      padding-bottom: ${theme.space.xs};
+      padding-bottom: ${theme.space.sm};
     }
 
     .key {

--- a/src/components/__tests__/SummaryTable.test.js
+++ b/src/components/__tests__/SummaryTable.test.js
@@ -51,12 +51,8 @@ describe('<SummaryTable>', () => {
       const $ = renderTable({ rows: rowsWithId })
 
       // first row
-      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name:')
       expect(getCell({ cheerio: $, rowNum: 0, find: '.value' }).text()).toEqual('Fred Smith')
-      expect(getCell({ cheerio: $, rowNum: 0, find: '.action' }).text()).toEqual('Change full name')
-      expect(getCell({ cheerio: $, rowNum: 0, find: '.action a' }).attr('href')).toEqual(
-        '/edit/name',
-      )
     })
 
     test('EXCLUDING edit links', () => {
@@ -65,7 +61,7 @@ describe('<SummaryTable>', () => {
       const $ = renderTable({ rows: rowsNoId })
 
       // first row
-      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name:')
       expect(getCell({ cheerio: $, rowNum: 0, find: '.value' }).text()).toEqual('Fred Smith')
       expect(getCell({ cheerio: $, rowNum: 0, find: '.action' }).length).toBe(0)
     })
@@ -78,17 +74,11 @@ describe('<SummaryTable>', () => {
       const $ = renderTable({ rows: rowsYesId })
 
       // first row
-      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name:')
 
       // second row
-      expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual('Date of birth')
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual('Date of birth:')
       expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual('18-06-1971')
-      expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).text()).toEqual(
-        'Change date of birth',
-      )
-      expect(getCell({ cheerio: $, rowNum: 1, find: '.action a' }).attr('href')).toEqual(
-        '/edit/dob',
-      )
     })
 
     test('EXCLUDING edit links', () => {
@@ -97,10 +87,10 @@ describe('<SummaryTable>', () => {
       const $ = renderTable({ rows: rowsNoId })
 
       // first row
-      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name')
+      expect(getCell({ cheerio: $, rowNum: 0, find: '.key' }).text()).toEqual('Full name:')
 
       // second row
-      expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual('Date of birth')
+      expect(getCell({ cheerio: $, rowNum: 1, find: '.key' }).text()).toEqual('Date of birth:')
       expect(getCell({ cheerio: $, rowNum: 1, find: '.value' }).text()).toEqual('18-06-1971')
       expect(getCell({ cheerio: $, rowNum: 1, find: '.action' }).length).toBe(0)
     })
@@ -121,7 +111,7 @@ describe('<SummaryRow>', () => {
   test('renders a row WITHOUT edit links', () => {
     const $ = renderRow(rows[0])
 
-    expect($('dt.key').text()).toEqual('Full name')
+    expect($('dt.key').text()).toEqual('Full name:')
     expect($('dd.value').text()).toEqual('Fred Smith')
     expect($('dd.action').length).toBe(0)
   })
@@ -129,8 +119,7 @@ describe('<SummaryRow>', () => {
   test('renders a row WITH edit links', () => {
     const $ = renderRow(rowsWithId[0])
 
-    expect($('dt.key').text()).toEqual('Full name')
+    expect($('dt.key').text()).toEqual('Full name:')
     expect($('dd.value').text()).toEqual('Fred Smith')
-    expect($('dd.action').text()).toBe('Change full name')
   })
 })

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -13,9 +13,9 @@ const inlineH2 = css`
   margin-top: 0;
 `
 
-const aboutYouRows = ({ name, address, maritalStatus, children, SIN }) => {
+const aboutYouRows = ({ firstName, lastName, address, maritalStatus, children, SIN }) => {
   return [
-    { key: 'Name', value: name, id: 'name' },
+    { key: 'Name', value: firstName + ' ' + lastName, id: 'name' },
     { key: 'Mailing address', value: address, id: 'address' },
     { key: 'Marital status', value: maritalStatus, id: 'maritalStatus' },
     { key: 'Number of children', value: children, id: 'children' },

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -1,5 +1,5 @@
 const { css } = require('emotion')
-const { loggedInStyles } = require('../styles.js')
+const { loggedInStyles, theme } = require('../styles.js')
 const { html } = require('../utils.js')
 const Layout = require('../components/Layout.js')
 const Accordion = require('../components/Accordion.js')
@@ -10,6 +10,11 @@ const polyglot = require('../i18n.js')
 
 const inlineH2 = css`
   display: inline-block;
+  margin-top: 0;
+  margin-right: ${theme.space.md};
+`
+
+const checklistH2 = css`
   margin-top: 0;
 `
 
@@ -34,14 +39,14 @@ const totalTaxRows = ({
   line482,
 } = {}) => {
   return [
-    { key: 'Basic personal amount (300):', value: line300, id: 'line300' },
-    { key: 'Spousal amount (303):', value: line303, id: 'line303' },
-    { key: 'Dependents amount (305):', value: line305, id: 'line305' },
-    { key: 'Caregiver amount (367):', value: line367, id: 'line367' },
-    { key: 'Disability amount (316):', value: line316, id: 'line316' },
-    { key: 'Medical Expenses (330):', value: line330, id: 'line330' },
-    { key: 'Medical Expenses (331):', value: line331, id: 'line331' },
-    { key: 'Total tax credits:', value: line482, id: 'line482' },
+    { key: 'Basic personal amount (300)', value: line300, id: 'line300' },
+    { key: 'Spousal amount (303)', value: line303, id: 'line303' },
+    { key: 'Dependents amount (305)', value: line305, id: 'line305' },
+    { key: 'Caregiver amount (367)', value: line367, id: 'line367' },
+    { key: 'Disability amount (316)', value: line316, id: 'line316' },
+    { key: 'Medical Expenses (330)', value: line330, id: 'line330' },
+    { key: 'Medical Expenses (331)', value: line331, id: 'line331' },
+    { key: 'Total tax credits', value: line482, id: 'line482' },
   ]
 }
 
@@ -57,18 +62,18 @@ const refundRows = ({
   line484,
 } = {}) => {
   return [
-    { key: 'Total Income (150):', value: line150, id: 'line150' },
-    { key: 'Net Income (236):', value: line236, id: 'line236' },
-    { key: 'Taxable Income (260):', value: line260, id: 'line260' },
-    { key: 'Net Federal Tax (420):', value: line420, id: 'line420' },
-    { key: 'Net Ontario Tax (428):', value: line428, id: 'line428' },
-    { key: 'Total Payable (435):', value: line435, id: 'line435' },
-    { key: 'Total Deducted (437):', value: line437, id: 'line437' },
-    { key: 'Total Credits (482):', value: line482, id: 'line482' },
-    { key: 'Total payable minus credits:', value: '400', id: 'totalPayableMinus' },
-    { key: 'Previous balance owed:', value: '0', id: 'previousBalance' },
-    { key: 'Current balance owed:', value: '0', id: 'currentBalance' },
-    { key: 'Refund (484):', value: line484, id: 'line484' },
+    { key: 'Total Income (150)', value: line150, id: 'line150' },
+    { key: 'Net Income (236)', value: line236, id: 'line236' },
+    { key: 'Taxable Income (260)', value: line260, id: 'line260' },
+    { key: 'Net Federal Tax (420)', value: line420, id: 'line420' },
+    { key: 'Net Ontario Tax (428)', value: line428, id: 'line428' },
+    { key: 'Total Payable (435)', value: line435, id: 'line435' },
+    { key: 'Total Deducted (437)', value: line437, id: 'line437' },
+    { key: 'Total Credits (482)', value: line482, id: 'line482' },
+    { key: 'Total payable minus credits', value: '400', id: 'totalPayableMinus' },
+    { key: 'Previous balance owed', value: '0', id: 'previousBalance' },
+    { key: 'Current balance owed', value: '0', id: 'currentBalance' },
+    { key: 'Refund (484)', value: line484, id: 'line484' },
   ]
 }
 
@@ -86,7 +91,7 @@ const Checklist = ({ user = {}, locale }) =>
           <${SummaryTable} rows=${aboutYouRows(user.personal)} />
         <//>
 
-        <h2>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
+        <h2 class=${checklistH2}>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
         <dl>
           <${SummaryRow} value=${user.return.line150} key="Total income:" />
@@ -95,7 +100,7 @@ const Checklist = ({ user = {}, locale }) =>
         </dl>
 
         <${Accordion} checked=${true}>
-          <${SummaryTable} rows=${totalTaxRows(user.return)} />
+          <${SummaryTable} currency=${true} rows=${totalTaxRows(user.return)} />
         <//>
 
         <dl>
@@ -103,7 +108,7 @@ const Checklist = ({ user = {}, locale }) =>
         </dl>
 
         <${Accordion} checked=${true}>
-          <${SummaryTable} rows=${refundRows(user.return)} />
+          <${SummaryTable} currency=${true} rows=${refundRows(user.return)} />
         <//>
 
         <h2 class=${inlineH2}>3.</h2>

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -94,9 +94,9 @@ const Checklist = ({ user = {}, locale }) =>
         <h2 class=${checklistH2}>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
         <dl>
-          <${SummaryRow} value=${user.return.line150} key="Total income:" />
-          <${SummaryRow} value=${user.return.line260} key="Taxable income:" />
-          <${SummaryRow} value=${user.return.line482} key="Total tax credits:" />
+          <${SummaryRow} value=${user.return.line150} key="Total income" />
+          <${SummaryRow} value=${user.return.line260} key="Taxable income" />
+          <${SummaryRow} value=${user.return.line482} key="Total tax credits" />
         </dl>
 
         <${Accordion} checked=${true}>

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -94,9 +94,9 @@ const Checklist = ({ user = {}, locale }) =>
         <h2 class=${checklistH2}>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
         <dl>
-          <${SummaryRow} value=${user.return.line150} key="Total income" />
-          <${SummaryRow} value=${user.return.line260} key="Taxable income" />
-          <${SummaryRow} value=${user.return.line482} key="Total tax credits" />
+          <${SummaryRow} currency=${true} value=${user.return.line150} key="Total income" />
+          <${SummaryRow} currency=${true} value=${user.return.line260} key="Taxable income" />
+          <${SummaryRow} currency=${true} value=${user.return.line482} key="Total tax credits" />
         </dl>
 
         <${Accordion} checked=${true}>
@@ -104,7 +104,7 @@ const Checklist = ({ user = {}, locale }) =>
         <//>
 
         <dl>
-          <${SummaryRow} value=${user.return.line484} key="Refund" />
+          <${SummaryRow} currency=${true} value=${user.return.line484} key="Refund" />
         </dl>
 
         <${Accordion} checked=${true}>

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -1,6 +1,6 @@
 const { css } = require('emotion')
 const { loggedInStyles, theme } = require('../styles.js')
-const { html } = require('../utils.js')
+const { html, currencyFormatter } = require('../utils.js')
 const Layout = require('../components/Layout.js')
 const Accordion = require('../components/Accordion.js')
 const LogoutLink = require('../components/LogoutLink.js')
@@ -20,11 +20,19 @@ const checklistH2 = css`
 
 const aboutYouRows = ({ firstName, lastName, address, maritalStatus, children, SIN }) => {
   return [
-    { key: 'Name', value: firstName + ' ' + lastName, id: 'name' },
-    { key: 'Mailing address', value: address, id: 'address' },
-    { key: 'Marital status', value: maritalStatus, id: 'maritalStatus' },
-    { key: 'Number of children', value: children, id: 'children' },
-    { key: 'Social Insurance Number (SIN)', value: SIN, id: 'sin' },
+<<<<<<< HEAD
+    { key: 'Name', value: firstName + ' ' + lastName },
+    { key: 'Mailing address', value: address },
+    { key: 'Marital status', value: maritalStatus },
+    { key: 'Number of children', value: children },
+    { key: 'Social Insurance Number (SIN)', value: SIN },
+=======
+    { key: 'Name', value: name },
+    { key: 'Mailing address', value: address },
+    { key: 'Marital status', value: maritalStatus },
+    { key: 'Number of children', value: children },
+    { key: 'Social Insurance Number (SIN)', value: SIN },
+>>>>>>> review changes
   ]
 }
 
@@ -39,14 +47,14 @@ const totalTaxRows = ({
   line482,
 } = {}) => {
   return [
-    { key: 'Basic personal amount (300)', value: line300, id: 'line300' },
-    { key: 'Spousal amount (303)', value: line303, id: 'line303' },
-    { key: 'Dependents amount (305)', value: line305, id: 'line305' },
+    { key: 'Basic personal amount (300)', value: line300 },
+    { key: 'Spousal amount (303)', value: line303 },
+    { key: 'Dependents amount (305)', value: line305 },
     { key: 'Caregiver amount (367)', value: line367, id: 'line367' },
-    { key: 'Disability amount (316)', value: line316, id: 'line316' },
-    { key: 'Medical Expenses (330)', value: line330, id: 'line330' },
+    { key: 'Disability amount (316)', value: line316 },
+    { key: 'Medical Expenses (330)', value: line330 },
     { key: 'Medical Expenses (331)', value: line331, id: 'line331' },
-    { key: 'Total', value: line482, id: 'line482' },
+    { key: 'Total', value: line482 },
   ]
 }
 
@@ -62,25 +70,35 @@ const refundRows = ({
   line484,
 } = {}) => {
   return [
-    { key: 'Total Income (150)', value: line150, id: 'line150' },
-    { key: 'Net Income (236)', value: line236, id: 'line236' },
+    { key: 'Total Income (150)', value: line150 },
+    { key: 'Net Income (236)', value: line236 },
     { key: 'Taxable Income (260)', value: line260, id: 'line260' },
-    { key: 'Net Federal Tax (420)', value: line420, id: 'line420' },
+    { key: 'Net Federal Tax (420)', value: line420 },
     { key: 'Net Ontario Tax (428)', value: line428, id: 'line428' },
-    { key: 'Total Payable (435)', value: line435, id: 'line435' },
-    { key: 'Total Deducted (437)', value: line437, id: 'line437' },
+    { key: 'Total Payable (435)', value: line435 },
+    { key: 'Total Deducted (437)', value: line437 },
     { key: 'Total Credits (482)', value: line482, id: 'line482' },
-    { key: 'Total payable minus credits', value: '400', id: 'totalPayableMinus' },
-    { key: 'Previous balance owed', value: '0', id: 'previousBalance' },
-    { key: 'Current balance owed', value: '0', id: 'currentBalance' },
-    { key: 'Total Refund (484)', value: line484, id: 'line484' },
+    { key: 'Total payable minus credits', value: '$400.00' },
+    { key: 'Previous balance owed', value: '$0.00' },
+    { key: 'Current balance owed', value: '$0.00', id: 'currentBalance' },
+    { key: 'Total Refund (484)', value: line484 },
   ]
+}
+
+var formattedUser = {}
+
+function myFunction(data) {
+  Object.entries(data).map(entry => {
+    var entryKey = entry[0]
+    var entryValue = entry[1]
+    formattedUser[entryKey] = currencyFormatter.format(entryValue)})
 }
 
 const Checklist = ({ user = {}, locale }) =>
   html`
     <${Layout}>
       <div class=${loggedInStyles}>
+      ${myFunction(user.return)}
         <${LogoutLink} />
         <h1>${polyglot.t(`${locale}.checklist.title`)}</h1>
         <p>
@@ -88,27 +106,27 @@ const Checklist = ({ user = {}, locale }) =>
         </p>
 
         <${Accordion} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
-          <${SummaryTable} keyBold=${true} rows=${aboutYouRows(user.personal)} />
+          <${SummaryTable} rows=${aboutYouRows(user.personal)} />
         <//>
 
         <h2 class=${checklistH2}>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
         <dl>
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line150} key="Total income" />
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line260} key="Taxable income" />
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line482} key="Total tax credits" />
+          <${SummaryRow} value=${formattedUser.line150} key="Total income" />
+          <${SummaryRow} value=${formattedUser.line260} key="Taxable income" />
+          <${SummaryRow} value=${formattedUser.line482} key="Total tax credits" />
         </dl>
 
         <${Accordion} checked=${true}>
-          <${SummaryTable} currency=${true} rows=${totalTaxRows(user.return)} />
+          <${SummaryTable} keyBold=${false} currency=${true} rows=${totalTaxRows(formattedUser)} />
         <//>
 
         <dl>
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line484} key="Refund" />
+          <${SummaryRow} currency=${true} value=${formattedUser.line484} key="Refund" />
         </dl>
 
         <${Accordion} checked=${true}>
-          <${SummaryTable} currency=${true} rows=${refundRows(user.return)} />
+          <${SummaryTable} keyBold=${false} currency=${true} rows=${refundRows(formattedUser)} />
         <//>
 
         <h2 class=${inlineH2}>3.</h2>

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -46,7 +46,7 @@ const totalTaxRows = ({
     { key: 'Disability amount (316)', value: line316, id: 'line316' },
     { key: 'Medical Expenses (330)', value: line330, id: 'line330' },
     { key: 'Medical Expenses (331)', value: line331, id: 'line331' },
-    { key: 'Total tax credits', value: line482, id: 'line482' },
+    { key: 'Total', value: line482, id: 'line482' },
   ]
 }
 
@@ -73,7 +73,7 @@ const refundRows = ({
     { key: 'Total payable minus credits', value: '400', id: 'totalPayableMinus' },
     { key: 'Previous balance owed', value: '0', id: 'previousBalance' },
     { key: 'Current balance owed', value: '0', id: 'currentBalance' },
-    { key: 'Refund (484)', value: line484, id: 'line484' },
+    { key: 'Total Refund (484)', value: line484, id: 'line484' },
   ]
 }
 
@@ -88,15 +88,15 @@ const Checklist = ({ user = {}, locale }) =>
         </p>
 
         <${Accordion} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
-          <${SummaryTable} rows=${aboutYouRows(user.personal)} />
+          <${SummaryTable} keyBold=${true} rows=${aboutYouRows(user.personal)} />
         <//>
 
         <h2 class=${checklistH2}>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
         <dl>
-          <${SummaryRow} currency=${true} value=${user.return.line150} key="Total income" />
-          <${SummaryRow} currency=${true} value=${user.return.line260} key="Taxable income" />
-          <${SummaryRow} currency=${true} value=${user.return.line482} key="Total tax credits" />
+          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line150} key="Total income" />
+          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line260} key="Taxable income" />
+          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line482} key="Total tax credits" />
         </dl>
 
         <${Accordion} checked=${true}>
@@ -104,7 +104,7 @@ const Checklist = ({ user = {}, locale }) =>
         <//>
 
         <dl>
-          <${SummaryRow} currency=${true} value=${user.return.line484} key="Refund" />
+          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line484} key="Refund" />
         </dl>
 
         <${Accordion} checked=${true}>

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -79,7 +79,7 @@ const refundRows = ({
 
 var formattedUser = {}
 
-function myFunction(data) {
+function currencyConverter(data) {
   Object.entries(data).map(entry => {
     var entryKey = entry[0]
     var entryValue = entry[1]
@@ -90,7 +90,7 @@ const Checklist = ({ user = {}, locale }) =>
   html`
     <${Layout}>
       <div class=${loggedInStyles}>
-      ${myFunction(user.return)}
+      ${currencyConverter(user.return)}
         <${LogoutLink} />
         <h1>${polyglot.t(`${locale}.checklist.title`)}</h1>
         <p>

--- a/src/pages/Checklist.js
+++ b/src/pages/Checklist.js
@@ -1,6 +1,6 @@
 const { css } = require('emotion')
 const { loggedInStyles, theme } = require('../styles.js')
-const { html } = require('../utils.js')
+const { html, currencyFormatter } = require('../utils.js')
 const Layout = require('../components/Layout.js')
 const Accordion = require('../components/Accordion.js')
 const LogoutLink = require('../components/LogoutLink.js')
@@ -20,11 +20,11 @@ const checklistH2 = css`
 
 const aboutYouRows = ({ name, address, maritalStatus, children, SIN }) => {
   return [
-    { key: 'Name', value: name, id: 'name' },
-    { key: 'Mailing address', value: address, id: 'address' },
-    { key: 'Marital status', value: maritalStatus, id: 'maritalStatus' },
-    { key: 'Number of children', value: children, id: 'children' },
-    { key: 'Social Insurance Number (SIN)', value: SIN, id: 'sin' },
+    { key: 'Name', value: name },
+    { key: 'Mailing address', value: address },
+    { key: 'Marital status', value: maritalStatus },
+    { key: 'Number of children', value: children },
+    { key: 'Social Insurance Number (SIN)', value: SIN },
   ]
 }
 
@@ -39,14 +39,14 @@ const totalTaxRows = ({
   line482,
 } = {}) => {
   return [
-    { key: 'Basic personal amount (300)', value: line300, id: 'line300' },
-    { key: 'Spousal amount (303)', value: line303, id: 'line303' },
-    { key: 'Dependents amount (305)', value: line305, id: 'line305' },
+    { key: 'Basic personal amount (300)', value: line300 },
+    { key: 'Spousal amount (303)', value: line303 },
+    { key: 'Dependents amount (305)', value: line305 },
     { key: 'Caregiver amount (367)', value: line367, id: 'line367' },
-    { key: 'Disability amount (316)', value: line316, id: 'line316' },
-    { key: 'Medical Expenses (330)', value: line330, id: 'line330' },
+    { key: 'Disability amount (316)', value: line316 },
+    { key: 'Medical Expenses (330)', value: line330 },
     { key: 'Medical Expenses (331)', value: line331, id: 'line331' },
-    { key: 'Total', value: line482, id: 'line482' },
+    { key: 'Total', value: line482 },
   ]
 }
 
@@ -62,25 +62,35 @@ const refundRows = ({
   line484,
 } = {}) => {
   return [
-    { key: 'Total Income (150)', value: line150, id: 'line150' },
-    { key: 'Net Income (236)', value: line236, id: 'line236' },
+    { key: 'Total Income (150)', value: line150 },
+    { key: 'Net Income (236)', value: line236 },
     { key: 'Taxable Income (260)', value: line260, id: 'line260' },
-    { key: 'Net Federal Tax (420)', value: line420, id: 'line420' },
+    { key: 'Net Federal Tax (420)', value: line420 },
     { key: 'Net Ontario Tax (428)', value: line428, id: 'line428' },
-    { key: 'Total Payable (435)', value: line435, id: 'line435' },
-    { key: 'Total Deducted (437)', value: line437, id: 'line437' },
+    { key: 'Total Payable (435)', value: line435 },
+    { key: 'Total Deducted (437)', value: line437 },
     { key: 'Total Credits (482)', value: line482, id: 'line482' },
-    { key: 'Total payable minus credits', value: '400', id: 'totalPayableMinus' },
-    { key: 'Previous balance owed', value: '0', id: 'previousBalance' },
-    { key: 'Current balance owed', value: '0', id: 'currentBalance' },
-    { key: 'Total Refund (484)', value: line484, id: 'line484' },
+    { key: 'Total payable minus credits', value: '$400.00' },
+    { key: 'Previous balance owed', value: '$0.00' },
+    { key: 'Current balance owed', value: '$0.00', id: 'currentBalance' },
+    { key: 'Total Refund (484)', value: line484 },
   ]
+}
+
+var formattedUser = {}
+
+function myFunction(data) {
+  Object.entries(data).map(entry => {
+    var entryKey = entry[0]
+    var entryValue = entry[1]
+    formattedUser[entryKey] = currencyFormatter.format(entryValue)})
 }
 
 const Checklist = ({ user = {}, locale }) =>
   html`
     <${Layout}>
       <div class=${loggedInStyles}>
+      ${myFunction(user.return)}
         <${LogoutLink} />
         <h1>${polyglot.t(`${locale}.checklist.title`)}</h1>
         <p>
@@ -88,27 +98,27 @@ const Checklist = ({ user = {}, locale }) =>
         </p>
 
         <${Accordion} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
-          <${SummaryTable} keyBold=${true} rows=${aboutYouRows(user.personal)} />
+          <${SummaryTable} rows=${aboutYouRows(user.personal)} />
         <//>
 
         <h2 class=${checklistH2}>${polyglot.t(`${locale}.checklist.financialInformation`)}</h2>
 
         <dl>
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line150} key="Total income" />
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line260} key="Taxable income" />
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line482} key="Total tax credits" />
+          <${SummaryRow} value=${formattedUser.line150} key="Total income" />
+          <${SummaryRow} value=${formattedUser.line260} key="Taxable income" />
+          <${SummaryRow} value=${formattedUser.line482} key="Total tax credits" />
         </dl>
 
         <${Accordion} checked=${true}>
-          <${SummaryTable} currency=${true} rows=${totalTaxRows(user.return)} />
+          <${SummaryTable} keyBold=${false} currency=${true} rows=${totalTaxRows(formattedUser)} />
         <//>
 
         <dl>
-          <${SummaryRow} keyBold=${true} currency=${true} value=${user.return.line484} key="Refund" />
+          <${SummaryRow} currency=${true} value=${formattedUser.line484} key="Refund" />
         </dl>
 
         <${Accordion} checked=${true}>
-          <${SummaryTable} currency=${true} rows=${refundRows(user.return)} />
+          <${SummaryTable} keyBold=${false} currency=${true} rows=${refundRows(formattedUser)} />
         <//>
 
         <h2 class=${inlineH2}>3.</h2>

--- a/src/pages/Confirmation.js
+++ b/src/pages/Confirmation.js
@@ -1,7 +1,6 @@
 const { css } = require('emotion')
 const { theme } = require('../styles.js')
 const { html } = require('../utils.js')
-const { getFirstName } = require('../api.js')
 const Layout = require('../components/Layout.js')
 const LogoutLink = require('../components/LogoutLink.js')
 
@@ -30,7 +29,7 @@ const Confirmation = ({ user = {} }) =>
       <div class=${confirmation}>
         <${LogoutLink} />
         <h1>Success! 🥳🙌</h1>
-        <p>🌈 Good job, ${getFirstName(user.personal.name)}! 🌈</p>
+        <p>🌈 Good job, ${user.personal.firstName}! 🌈</p>
         <p>
           Your 2018 taxes have been submitted and${' '}
           <strong>you will receive $1611.87 in benefit payments</strong>.

--- a/src/pages/Introduction.js
+++ b/src/pages/Introduction.js
@@ -1,6 +1,5 @@
 const { loggedInStyles } = require('../styles.js')
 const { html } = require('../utils.js')
-const { getFirstName } = require('../api.js')
 const Layout = require('../components/Layout.js')
 const LogoutLink = require('../components/LogoutLink.js')
 const ButtonLink = require('../components/ButtonLink.js')
@@ -10,7 +9,7 @@ const Introduction = ({ user = {} }) =>
     <${Layout}>
       <div class=${loggedInStyles}>
         <${LogoutLink} />
-        <h1>Hi, ${getFirstName(user.personal.name)}</h1>
+        <h1>Hi, ${user.personal.firstName}</h1>
         <p>
           Here’s what we know about you based on your previous tax returns and information from your
           employer.

--- a/src/pages/__tests__/Checklist.test.js
+++ b/src/pages/__tests__/Checklist.test.js
@@ -7,7 +7,7 @@ describe('<CheckList>', () => {
   const data = {
     _matches: ['john', 'j'],
     personal: {
-      name: 'John Caldwell Abbott',
+      firstName: 'John',
       address: '21275 Lakeshore Dr\nSainte-Anne-de-Bellevue\nQuébec\nH9X 3L9',
       maritalStatus: 'Widowed',
       children: '8',

--- a/src/pages/__tests__/Checklist.test.js
+++ b/src/pages/__tests__/Checklist.test.js
@@ -1,6 +1,6 @@
 const render = require('preact-render-to-string')
 const cheerio = require('cheerio')
-const { html } = require('../../utils.js')
+const { html, currencyFormatter } = require('../../utils.js')
 const Checklist = require('../Checklist.js')
 
 describe('<CheckList>', () => {
@@ -37,7 +37,7 @@ describe('<CheckList>', () => {
   }
 
   const expectedStringspersonal = Object.values(data.personal)
-  const expectedStringsReturn = Object.values(data.return)
+  const expectedStringsReturn = Object.values(currencyFormatter.format(data.return))
 
   test('renders h1 as expected', () => {
     const $ = cheerio.load(

--- a/src/pages/__tests__/Introduction.test.js
+++ b/src/pages/__tests__/Introduction.test.js
@@ -7,7 +7,7 @@ const Introduction = require('../Introduction.js')
 describe('<Introduction>', () => {
   const user = {
     personal: {
-      name: 'Arthur Meighen',
+      firstName: 'Arthur',
     },
   }
 
@@ -53,7 +53,7 @@ describe('<Introduction>', () => {
     })
   })
 
-  /* 
+  /*
 
 expectedH2s.map((str, i) => {
     test(`renders h2 with "${str}"`, () => {

--- a/src/styles.js
+++ b/src/styles.js
@@ -105,6 +105,10 @@ p {
   font-size: 18px;
 }
 
+p::before {
+  content: 'Hide details';
+}
+
 div[name='accordion'] {
   position: relative;
   overflow: hidden;
@@ -168,6 +172,10 @@ li {
         max-height: 0;
         opacity: 0;
         transform: translate(0, 50%);
+      }
+
+      & ~ p::before {
+        content: 'Show details';
       }
 
       & ~ i {

--- a/src/styles.js
+++ b/src/styles.js
@@ -117,24 +117,14 @@ const accordionStyles = css`
     transform: translate(0, 0);
     margin-top: 14px;
     z-index: 2;
-  }
 
-  #line367 dt.key,
-  #line367 dd.value,
-  #line331 dt.key,
-  #line331 dd.value,
-  #line260 dt.key,
-  #line260 dd.value,
-  #line428 dt.key,
-  #line428 dd.value,
-  #line482 dt.key,
-  #line482 dd.value,
-  #currentBalance dt.key,
-  #currentBalance dd.value {
-    padding-bottom: ${theme.space.xl};
-
-    @media (${theme.mq.sm}) {
-      padding-bottom: 0;
+    #line367 dt,
+    #line331 dt,
+    #line260 dt,
+    #line428 dt,
+    #line482 dt,
+    #currentBalance dt {
+      padding-bottom: ${theme.space.xl};
     }
   }
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -77,6 +77,10 @@ const loggedInStyles = css`
     margin-bottom: ${theme.space.sm};
   }
 
+  dl {
+    margin-bottom: 0;
+  }
+
   button,
   a.buttonLink {
     width: 200px;
@@ -90,104 +94,123 @@ const loggedInStyles = css`
 `
 
 const accordionStyles = css`
-h2 {
-  font-weight: 700;
-  letter-spacing: 1px;
-  display: block;
-  background-color: white;
-  margin: 0;
-  cursor: pointer;
-  @extend .no-select;
-}
-
-p {
-  margin: 0;
-  font-size: 18px;
-}
-
-p::before {
-  content: 'Hide details';
-  font-style: italic;
-}
-
-div[name='accordion'] {
-  position: relative;
-  overflow: hidden;
-  opacity: 1;
-  transform: translate(0, 0);
-  margin-top: 14px;
-  z-index: 2;
-}
-
-ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-li {
-  position: relative;
-  padding: 0;
-  margin: 0;
-  padding-bottom: 4px;
-  padding-top: 18px;
-  border-top: 1px dotted grey;
-
-  i {
-    position: absolute;
-    transform: translate(-6px, 0);
-    margin-top: 16px;
-    right: 0;
-
-    &:before,
-    &:after {
-      content: '';
-      position: absolute;
-      background-color: black;
-      width: 3px;
-      height: 9px;
-    }
-
-    &:before {
-      transform: translate(-2px, 0) rotate(45deg);
-    }
-
-    &:after {
-      transform: translate(2px, 0) rotate(-45deg);
-    }
-  }
-
-  input[type='checkbox'] {
-    position: absolute;
+  h2 {
+    font-weight: 700;
+    letter-spacing: 1px;
+    display: block;
+    background-color: white;
+    margin: 0;
     cursor: pointer;
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-    opacity: 0;
+    @extend .no-select;
+  }
 
-    &:checked {
-      & ~ div[name='accordion'] {
-        margin-top: 0;
-        max-height: 0;
-        opacity: 0;
-        transform: translate(0, 50%);
+  p {
+    margin: 0;
+    font-size: 18px;
+  }
+
+  p::before {
+    content: 'Hide details';
+    font-style: italic;
+  }
+
+  div[name='accordion'] {
+    position: relative;
+    overflow: hidden;
+    opacity: 1;
+    transform: translate(0, 0);
+    margin-top: 14px;
+    z-index: 2;
+  }
+
+  #line367 dt.key,
+  #line367 dd.value,
+  #line331 dt.key,
+  #line331 dd.value,
+  #line260 dt.key,
+  #line260 dd.value,
+  #line428 dt.key,
+  #line428 dd.value,
+  #line482 dt.key,
+  #line482 dd.value,
+  #currentBalance dt.key,
+  #currentBalance dd.value {
+    padding-bottom: ${theme.space.xl};
+
+    @media (${theme.mq.sm}) {
+      padding-bottom: 0;
+    }
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    position: relative;
+    padding: 0;
+    margin: 0;
+    padding-bottom: ${theme.space.sm};
+    padding-top: ${theme.space.xs};
+    border-bottom: 1px dotted grey;
+
+    i {
+      position: absolute;
+      transform: translate(-6px, 0);
+      margin-top: 16px;
+      right: 0;
+
+      &:before,
+      &:after {
+        content: '';
+        position: absolute;
+        background-color: black;
+        width: 3px;
+        height: 9px;
       }
 
-      & ~ p::before {
-        content: 'Show details';
+      &:before {
+        transform: translate(-2px, 0) rotate(45deg);
       }
 
-      & ~ i {
-        &:before {
-          transform: translate(2px, 0) rotate(45deg);
+      &:after {
+        transform: translate(2px, 0) rotate(-45deg);
+      }
+    }
+
+    input[type='checkbox'] {
+      position: absolute;
+      cursor: pointer;
+      width: 100%;
+      height: 100%;
+      z-index: 1;
+      opacity: 0;
+
+      &:checked {
+        & ~ div[name='accordion'] {
+          margin-top: 0;
+          max-height: 0;
+          opacity: 0;
+          transform: translate(0, 50%);
         }
-        &:after {
-          transform: translate(-2px, 0) rotate(-45deg);
+
+        & ~ p::before {
+          content: 'Show details';
+        }
+
+        & ~ i {
+          &:before {
+            transform: translate(2px, 0) rotate(45deg);
+          }
+          &:after {
+            transform: translate(-2px, 0) rotate(-45deg);
+          }
         }
       }
     }
   }
-}
 `
 
 module.exports = {

--- a/src/styles.js
+++ b/src/styles.js
@@ -107,10 +107,6 @@ const accordionStyles = css`
   p {
     margin: 0;
     font-size: 18px;
-  }
-
-  p::before {
-    content: 'Hide details';
     font-style: italic;
   }
 
@@ -194,10 +190,6 @@ const accordionStyles = css`
           max-height: 0;
           opacity: 0;
           transform: translate(0, 50%);
-        }
-
-        & ~ p::before {
-          content: 'Show details';
         }
 
         & ~ i {

--- a/src/styles.js
+++ b/src/styles.js
@@ -74,7 +74,7 @@ const loggedInStyles = css`
   position: relative;
 
   > div {
-    margin-bottom: ${theme.space.xl};
+    margin-bottom: ${theme.space.sm};
   }
 
   button,
@@ -107,12 +107,12 @@ p {
 
 p::before {
   content: 'Hide details';
+  font-style: italic;
 }
 
 div[name='accordion'] {
   position: relative;
   overflow: hidden;
-  max-height: 800px;
   opacity: 1;
   transform: translate(0, 0);
   margin-top: 14px;
@@ -121,7 +121,6 @@ div[name='accordion'] {
 
 ul {
   list-style: none;
-  perspective: 900;
   padding: 0;
   margin: 0;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,6 +104,12 @@ const errorArray2ErrorObject = (errors = []) => {
   }, {})
 }
 
+const currencyFormatter = new Intl.NumberFormat('en-CAD', {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2
+})
+
 module.exports = {
   html,
   metaIfSHA,
@@ -113,4 +119,5 @@ module.exports = {
   loginSchema,
   introductionSchema,
   errorArray2ErrorObject,
+  currencyFormatter,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -107,7 +107,7 @@ const errorArray2ErrorObject = (errors = []) => {
 const currencyFormatter = new Intl.NumberFormat('en-CAD', {
   style: 'currency',
   currency: 'USD',
-  minimumFractionDigits: 2
+  minimumFractionDigits: 2,
 })
 
 module.exports = {


### PR DESCRIPTION
## This PR consists of the following:

### Removed the `Change` Buttons in personal and financial data tables

| Before | After |
|--------|-------|
| <img width="1100" alt="Screen Shot 2019-05-28 at 11 45 15" src="https://user-images.githubusercontent.com/30609058/58492036-1d3cf380-813e-11e9-906b-95f1c4354e4c.png">|<img width="1100" alt="Screen Shot 2019-05-28 at 11 45 24" src="https://user-images.githubusercontent.com/30609058/58492035-1d3cf380-813e-11e9-89b8-bbd84ee377bf.png"> | 

### Style matches Cayce's mockups more closely
- Bolded keys match mockup
- Grouping of certain elements in financial information

### Currency converter
- Financial info is now being converted into dollars

| Before | After |
|--------|-------|
| <img width="1100" alt="Screen Shot 2019-05-28 at 11 51 03" src="https://user-images.githubusercontent.com/30609058/58492688-693c6800-813f-11e9-82ce-19516e8a963e.png"> | <img width="1100" alt="Screen Shot 2019-05-28 at 11 50 51" src="https://user-images.githubusercontent.com/30609058/58492428-e4514e80-813e-11e9-82f4-f547d86d3fd5.png"> | 

### Minor unit test updates
- Removed `:` from key value and added it into the component template, test needed to be updated
- Currency converter needed to be added to the Checklist.test.js page test

### Minor Cypress end 2 end update
- adding the `.keyBold` class upset a cypress test checking for `.key` 
- We can update the tests later to account for the default-weighted key values in the financial information section