### PR TITLE
[WIP] Refactor accordion component

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,96 @@
+/* eslint-disable no-undef */
+/*
+ *   This content is licensed according to the W3C Software License at
+ *   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ *   Simple accordion pattern example
+ */
+
+'use strict'
+
+Array.prototype.slice.call(document.querySelectorAll('.Accordion')).forEach(function(accordion) {
+  // Create the array of toggle elements for the accordion group
+  var triggers = Array.prototype.slice.call(accordion.querySelectorAll('.Accordion-trigger'))
+
+  accordion.addEventListener('click', function(event) {
+    var target = event.target
+
+    if (target.classList.contains('Accordion-trigger')) {
+      // Check if the current toggle is expanded.
+      var isExpanded = target.getAttribute('aria-expanded') == 'true'
+
+      if (!isExpanded) {
+        // Set the expanded state on the triggering element
+        target.setAttribute('aria-expanded', 'true')
+        // Hide the accordion sections, using aria-controls to specify the desired section
+        document.getElementById(target.getAttribute('aria-controls')).removeAttribute('hidden')
+
+        document.getElementById(target.id).querySelector('.Accordion-trigger-label').textContent =
+          'Hide'
+      } else if (isExpanded) {
+        // Set the expanded state on the triggering element
+        target.setAttribute('aria-expanded', 'false')
+        // Hide the accordion sections, using aria-controls to specify the desired section
+        document.getElementById(target.getAttribute('aria-controls')).setAttribute('hidden', '')
+
+        document.getElementById(target.id).querySelector('.Accordion-trigger-label').textContent =
+          'Show'
+      }
+
+      event.preventDefault()
+    }
+  })
+
+  // Bind keyboard behaviors on the main accordion container
+  accordion.addEventListener('keydown', function(event) {
+    var target = event.target
+    var key = event.which.toString()
+
+    // 33 = Page Up, 34 = Page Down
+    var ctrlModifier = event.ctrlKey && key.match(/33|34/)
+
+    // Is this coming from an accordion header?
+    if (target.classList.contains('Accordion-trigger')) {
+      // Up/ Down arrow and Control + Page Up/ Page Down keyboard operations
+      // 38 = Up, 40 = Down
+      if (key.match(/38|40/) || ctrlModifier) {
+        var index = triggers.indexOf(target)
+        var direction = key.match(/34|40/) ? 1 : -1
+        var length = triggers.length
+        var newIndex = (index + length + direction) % length
+
+        triggers[newIndex].focus()
+
+        event.preventDefault()
+      } else if (key.match(/35|36/)) {
+        // 35 = End, 36 = Home keyboard operations
+
+        /* eslint-disable indent */
+        switch (key) {
+          // Go to first accordion
+          case '36':
+            triggers[0].focus()
+            break
+          // Go to last accordion
+          case '35':
+            triggers[triggers.length - 1].focus()
+            break
+        }
+        /* eslint-enable indent */
+
+        event.preventDefault()
+      }
+    }
+  })
+
+  // These are used to style the accordion when one of the buttons has focus
+  accordion.querySelectorAll('.Accordion-trigger').forEach(function(trigger) {
+    trigger.addEventListener('focus', function() {
+      accordion.classList.add('focus')
+    })
+
+    trigger.addEventListener('blur', function() {
+      accordion.classList.remove('focus')
+    })
+  })
+})

--- a/src/pages/Acc.js
+++ b/src/pages/Acc.js
@@ -2,121 +2,10 @@ const { css } = require('emotion')
 const { loggedInStyles, theme, visuallyHidden } = require('../styles.js')
 const { html } = require('../utils.js')
 const Layout = require('../components/Layout.js')
-const LogoutLink = require('../components/LogoutLink.js')
 const { SummaryTable } = require('../components/SummaryTable.js')
 const polyglot = require('../i18n.js')
 
 const accordionStyles = css`
-  h2 {
-    font-weight: 700;
-    letter-spacing: 1px;
-    display: block;
-    background-color: white;
-    margin: 0;
-    cursor: pointer;
-    @extend .no-select;
-  }
-
-  p {
-    margin: 0;
-    font-size: 18px;
-  }
-
-  div[name='accordion'] {
-    position: relative;
-    overflow: hidden;
-    max-height: 800px;
-    opacity: 1;
-    transform: translate(0, 0);
-    margin-top: 14px;
-    z-index: 2;
-  }
-
-  ul {
-    list-style: none;
-    perspective: 900;
-    padding: 0;
-    margin: 0;
-  }
-
-  li {
-    position: relative;
-    padding: 0;
-    margin: 0;
-    padding-bottom: 4px;
-    padding-top: 18px;
-    border-top: 1px dotted grey;
-
-    i {
-      position: absolute;
-      transform: translate(-6px, 0);
-      margin-top: 16px;
-      right: 0;
-
-      &:before,
-      &:after {
-        content: '';
-        position: absolute;
-        background-color: black;
-        width: 3px;
-        height: 9px;
-      }
-
-      &:before {
-        transform: translate(-2px, 0) rotate(45deg);
-      }
-
-      &:after {
-        transform: translate(2px, 0) rotate(-45deg);
-      }
-    }
-
-    input[type='checkbox'] {
-      position: absolute;
-      cursor: pointer;
-      width: 100%;
-      height: 100%;
-      z-index: 1;
-      opacity: 0;
-
-      &:checked {
-        & ~ div[name='accordion'] {
-          margin-top: 0;
-          max-height: 0;
-          opacity: 0;
-          transform: translate(0, 50%);
-        }
-
-        & ~ i {
-          &:before {
-            transform: translate(2px, 0) rotate(45deg);
-          }
-          &:after {
-            transform: translate(-2px, 0) rotate(-45deg);
-          }
-        }
-      }
-    }
-  }
-`
-
-const Accordion = ({ children, header, checked }) =>
-  html`
-    <div class=${accordionStyles}>
-      <ul>
-        <li>
-          <input type="checkbox" ${checked ? 'checked' : null} /><i></i>
-          <h2>${header}</h2>
-
-          <div name="accordion">
-            ${children}
-          </div>
-        </li>
-      </ul>
-    </div>
-  `
-
-const accordion2styles = css`
   .Accordion {
     border-top: 1px dashed ${theme.color.black};
     border-bottom: 1px dashed ${theme.color.black};
@@ -198,9 +87,9 @@ const accordion2styles = css`
   }
 `
 
-const Accordion2 = ({ children, header, open = false }) =>
+const Accordion = ({ children, header, open = true }) =>
   html`
-    <div class=${accordion2styles}>
+    <div class=${accordionStyles}>
       <div id="accordionGroup" class="Accordion">
         <button
           aria-expanded=${open === (false || 'false') ? 'false' : 'true'}
@@ -242,17 +131,7 @@ const Acc = ({ user = {}, locale }) =>
   html`
     <${Layout}>
       <div class=${loggedInStyles}>
-        <${LogoutLink} />
-        <h1>${polyglot.t(`${locale}.checklist.title`)}</h1>
-        <p>
-          ${polyglot.t(`${locale}.checklist.intro`)}
-        </p>
-
         <${Accordion} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
-          <${SummaryTable} rows=${aboutYouRows(user.personal)} />
-        <//>
-
-        <${Accordion2} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
           <${SummaryTable} rows=${aboutYouRows(user.personal)} />
         <//>
       </div>

--- a/src/pages/Acc.js
+++ b/src/pages/Acc.js
@@ -1,0 +1,262 @@
+const { css } = require('emotion')
+const { loggedInStyles, theme, visuallyHidden } = require('../styles.js')
+const { html } = require('../utils.js')
+const Layout = require('../components/Layout.js')
+const LogoutLink = require('../components/LogoutLink.js')
+const { SummaryTable } = require('../components/SummaryTable.js')
+const polyglot = require('../i18n.js')
+
+const accordionStyles = css`
+  h2 {
+    font-weight: 700;
+    letter-spacing: 1px;
+    display: block;
+    background-color: white;
+    margin: 0;
+    cursor: pointer;
+    @extend .no-select;
+  }
+
+  p {
+    margin: 0;
+    font-size: 18px;
+  }
+
+  div[name='accordion'] {
+    position: relative;
+    overflow: hidden;
+    max-height: 800px;
+    opacity: 1;
+    transform: translate(0, 0);
+    margin-top: 14px;
+    z-index: 2;
+  }
+
+  ul {
+    list-style: none;
+    perspective: 900;
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    position: relative;
+    padding: 0;
+    margin: 0;
+    padding-bottom: 4px;
+    padding-top: 18px;
+    border-top: 1px dotted grey;
+
+    i {
+      position: absolute;
+      transform: translate(-6px, 0);
+      margin-top: 16px;
+      right: 0;
+
+      &:before,
+      &:after {
+        content: '';
+        position: absolute;
+        background-color: black;
+        width: 3px;
+        height: 9px;
+      }
+
+      &:before {
+        transform: translate(-2px, 0) rotate(45deg);
+      }
+
+      &:after {
+        transform: translate(2px, 0) rotate(-45deg);
+      }
+    }
+
+    input[type='checkbox'] {
+      position: absolute;
+      cursor: pointer;
+      width: 100%;
+      height: 100%;
+      z-index: 1;
+      opacity: 0;
+
+      &:checked {
+        & ~ div[name='accordion'] {
+          margin-top: 0;
+          max-height: 0;
+          opacity: 0;
+          transform: translate(0, 50%);
+        }
+
+        & ~ i {
+          &:before {
+            transform: translate(2px, 0) rotate(45deg);
+          }
+          &:after {
+            transform: translate(-2px, 0) rotate(-45deg);
+          }
+        }
+      }
+    }
+  }
+`
+
+const Accordion = ({ children, header, checked }) =>
+  html`
+    <div class=${accordionStyles}>
+      <ul>
+        <li>
+          <input type="checkbox" ${checked ? 'checked' : null} /><i></i>
+          <h2>${header}</h2>
+
+          <div name="accordion">
+            ${children}
+          </div>
+        </li>
+      </ul>
+    </div>
+  `
+
+const accordion2styles = css`
+  .Accordion {
+    border-top: 1px dashed ${theme.color.black};
+    border-bottom: 1px dashed ${theme.color.black};
+  }
+
+  .Accordion-trigger {
+    font-size: 1em;
+    margin: 0;
+    position: relative;
+    text-align: left;
+    width: 100%;
+  }
+
+  button {
+    background: none;
+    border-style: none;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  button::-moz-focus-inner {
+    border: 0;
+  }
+
+  button h2 {
+    margin-right: ${theme.space.xxl};
+  }
+
+  .Accordion-title {
+    display: block;
+    pointer-events: none;
+  }
+
+  .Accordion-trigger-label {
+    position: absolute;
+    top: 40%;
+    right: ${theme.space.xl};
+    color: ${theme.color.link};
+  }
+
+  .Accordion-icon {
+    border: solid ${theme.color.link};
+    border-width: 0 3px 3px 0;
+    pointer-events: none;
+    position: absolute;
+    right: ${theme.space.sm};
+    top: 50%;
+    transform: translateY(-60%) rotate(45deg);
+    height: 0.6rem;
+    width: 0.6rem;
+  }
+
+  .Accordion-trigger[aria-expanded='true'] .Accordion-icon {
+    transform: translateY(-50%) rotate(-135deg);
+  }
+
+  .Accordion-panel {
+    margin: 0;
+  }
+
+  /* For Edge bug https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/4806035/ */
+  .Accordion-panel[hidden] {
+    display: none;
+  }
+
+  /* Focus styles */
+  .Accordion-trigger:focus,
+  .Accordion-trigger:hover {
+    background: aliceblue;
+
+    & .Accordion-trigger-label {
+      text-decoration: underline;
+    }
+
+    & .Accordion-icon {
+      border-color: blue;
+      text-decoration: underline;
+    }
+  }
+`
+
+const Accordion2 = ({ children, header, open = false }) =>
+  html`
+    <div class=${accordion2styles}>
+      <div id="accordionGroup" class="Accordion">
+        <button
+          aria-expanded=${open === (false || 'false') ? 'false' : 'true'}
+          class="Accordion-trigger"
+          aria-controls="sect1"
+          id="accordion1id"
+        >
+          <span class="Accordion-title">
+            <h2>
+              ${header}
+            </h2>
+            <span class="Accordion-trigger-label"
+              >${open === (false || 'false') ? 'Show' : 'Hide'}
+              <span class=${visuallyHidden}>${header}</span></span
+            >
+            <span class="Accordion-icon"></span>
+          </span>
+        </button>
+        <div id="sect1" role="region" aria-labelledby="accordion1id" class="Accordion-panel">
+          <div>
+            ${children}
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+
+const aboutYouRows = ({ name, address, maritalStatus, children, SIN }) => {
+  return [
+    { key: 'Name', value: name, id: 'name' },
+    { key: 'Mailing address', value: address, id: 'address' },
+    { key: 'Marital status', value: maritalStatus, id: 'maritalStatus' },
+    { key: 'Number of children', value: children, id: 'children' },
+    { key: 'Social Insurance Number (SIN)', value: SIN, id: 'sin' },
+  ]
+}
+
+const Acc = ({ user = {}, locale }) =>
+  html`
+    <${Layout}>
+      <div class=${loggedInStyles}>
+        <${LogoutLink} />
+        <h1>${polyglot.t(`${locale}.checklist.title`)}</h1>
+        <p>
+          ${polyglot.t(`${locale}.checklist.intro`)}
+        </p>
+
+        <${Accordion} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
+          <${SummaryTable} rows=${aboutYouRows(user.personal)} />
+        <//>
+
+        <${Accordion2} header="${polyglot.t(`${locale}.checklist.personalInformation`)}">
+          <${SummaryTable} rows=${aboutYouRows(user.personal)} />
+        <//>
+      </div>
+    <//>
+  `
+
+module.exports = Acc

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -31,6 +31,10 @@ const document = ({ title, locale, content }) => {
             line-height: 1.33;
           }
 
+          button {
+            font-family: sans-serif;
+          }
+
           h1 {
             margin-top: 35px;
             margin-bottom: 25px;
@@ -43,6 +47,7 @@ const document = ({ title, locale, content }) => {
       </head>
       <body>
         ${content}
+        <script src="/script.js"></script>
       </body>
     </html>
   `

--- a/src/server.js
+++ b/src/server.js
@@ -85,6 +85,19 @@ app.get('/introduction', checkLogin, (req, res) => {
   )
 })
 
+app.get('/acc', checkLogin, (req, res) => {
+  const user = getSessionData(req.session)
+
+  res.send(
+    renderPage({
+      locale,
+      title: 'TEST',
+      pageComponent: 'Acc',
+      props: { user, locale },
+    }),
+  )
+})
+
 app.get('/checklist', checkLogin, (req, res) => {
   const user = getSessionData(req.session)
 

--- a/src/styles.js
+++ b/src/styles.js
@@ -13,6 +13,7 @@ const theme = {
     focus: '#ffbf47',
     green: 'aquamarine',
     error: '#b10e1e',
+    link: '#0645ad',
   },
   space: {
     xxs: '5px',


### PR DESCRIPTION
⚠️  **Don't merge!**  ⚠️ 

As is, our CSS-only accordions are super cool, but we need dynamic stuff (ie, JavaScript) to update the aria attributes so that they are accessible. 

**To see the accordion, visit the "deployed" link, log in, and then manually go to the `/acc`.**

---

Went to the [Aria Practices Authoring Guide](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion) and found [their accordion example](https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html) and then just stole it.

Added a script.js file into the app, but I figured this was coming down the line anyway.

Should be pretty accessible: handles all the keyboard interactions that the Aria authoring practices recommends and also adds the correct aria attributes.

Created a new page (`/acc`) and put the existing accordion on it so that I could see both accordions side by side. This is very spike, this new page will be deleted and the new Accordion should replace the existing code in components/Accordion.js.