### PR TITLE
Update name validation

### DIFF
--- a/src/questions/name.js
+++ b/src/questions/name.js
@@ -10,6 +10,10 @@ module.exports = {
         errorMessage: 'Name can’t be empty',
         negated: true,
       },
+      isLength: {
+        errorMessage: 'Name must be at least 13 characters long',
+        options: { min: 13 },
+      },
       trim: true,
     },
   },


### PR DESCRIPTION
Require names to be 13 characters long. 

This is a UX intervention to encourage people to enter their middle name(s). 

For shorter names, we recommend left padding first names with `0`.
(for example, `000Paul Craig`)