### PR TITLE
Move Dockerfile linting into separate workflow file

### DIFF
--- a/.github/workflows/lintDockerfile.yml
+++ b/.github/workflows/lintDockerfile.yml
@@ -1,0 +1,9 @@
+on: push
+name: Lint Dockerfile
+jobs:
+  scan:
+    name: Lint Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: docker://cdssnc/docker-lint

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -6,5 +6,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Scan for secrets
-        uses: docker://cdssnc/seekret-github-action
+      - uses: docker://cdssnc/seekret-github-action

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Lint Dockerfile
-        uses: docker://cdssnc/docker-lint
       - name: Install npm dependencies
         uses: actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680
         with:

--- a/.github/workflows/testBuildDeploy.yml
+++ b/.github/workflows/testBuildDeploy.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Lint Dockerfile
-        uses: docker://cdssnc/docker-lint
       - name: Install npm dependencies
         uses: actions/npm@59b64a598378f31e49cb76f27d6f3312b582f680
         with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://github.com/cds-snc/cra-alpha/workflows/Test,%20build,%20deploy/badge.svg)
+
 # CRA Alpha
 
 This is a small frontend to trial user flows for a future CRA service that will help Canadians receive the benefits to which they are entitled.


### PR DESCRIPTION
Reduces a tiny bit of duplication.

Also add the deploy badge to the README.