### PR TITLE
Rewrite Github actions to build Docker image and deploy

### DIFF
--- a/.github/workflows/testBuildDeploy.yml
+++ b/.github/workflows/testBuildDeploy.yml
@@ -2,7 +2,7 @@ name: Test, build, deploy
 on:
   push:
     branches:
-      - actions
+      - master
 jobs:
   test:
     name: Run tests

--- a/.github/workflows/testBuildDeploy.yml
+++ b/.github/workflows/testBuildDeploy.yml
@@ -2,7 +2,7 @@ name: Test, build, deploy
 on:
   push:
     branches:
-      - master
+      - actions
 jobs:
   test:
     name: Run tests
@@ -31,27 +31,19 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@master
-      - name: Build a Docker container
-        uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-        with:
-          args: build -t base --build-arg GITHUB_SHA_ARG=${{ github.sha }} .
+      - name: Build the Docker image
+        run: docker build -t base --build-arg GITHUB_SHA_ARG=${{ github.sha }} .
       - name: Tag :latest
-        uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-        with:
-          args: tag base cdssnc/cra-alpha:latest
+        run: docker tag base cdssnc/cra-alpha:latest
       - name: Tag :$GITHUB_SHA
-        uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-        with:
-          args: tag base cdssnc/cra-alpha:${{ github.sha }}
-      - name: Login to Docker Hub
-        uses: actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108
+        run: docker tag base cdssnc/cra-alpha:${{ github.sha }}
+      - name: Login into Docker Hub
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
       - name: Push container to Docker Hub
-        uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-        with:
-          args: push cdssnc/cra-alpha
+        run: docker push cdssnc/cra-alpha
       - name: Login to Azure
         uses: Azure/github-actions/login@d0e5a0afc6b9d8d19c9ade8e2446ef3c20e260d4
         env:


### PR DESCRIPTION
The erstwhile `github.com/actions/docker` repo is archived now, so
we can't build docker images anymore the way we used to.

Found another helpful repo here with the basic idea and then extrapolated:
- https://github.com/actions/starter-workflows/blob/ee61b8e679dd64c331f3c596a0ca6095d1fb62bb/ci/docker-image.yml

Also this tweet thread was kind of helpful:
- https://twitter.com/pst418/status/1181480140867559424